### PR TITLE
physical plan: move shared resources from exec nodes

### DIFF
--- a/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
+++ b/datafusion/core/src/datasource/physical_plan/parquet/mod.rs
@@ -709,7 +709,6 @@ impl ExecutionPlan for ParquetExec {
             .clone()
             .unwrap_or_else(|| Arc::new(DefaultSchemaAdapterFactory::default()));
 
-        println!("parquet exec registered metrics...");
         let metrics = ctx.get_or_register_metric_set_with_default(self, || {
             ExecutionPlanMetricsSet::with_inner(self.base_metrics.clone_inner())
         });

--- a/datafusion/execution/src/lib.rs
+++ b/datafusion/execution/src/lib.rs
@@ -39,4 +39,4 @@ pub use disk_manager::DiskManager;
 pub use metrics::Metric;
 pub use registry::FunctionRegistry;
 pub use stream::{RecordBatchStream, SendableRecordBatchStream};
-pub use task::TaskContext;
+pub use task::{PlanState, TaskContext};

--- a/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
+++ b/datafusion/physical-plan/src/joins/symmetric_hash_join.rs
@@ -1642,6 +1642,7 @@ mod tests {
             Arc::clone(&task_ctx),
         )
         .await?;
+        let task_ctx = Arc::new(task_ctx.fork());
         let second_batches = partitioned_hash_join_with_filter(
             left, right, on, filter, &join_type, false, task_ctx,
         )

--- a/datafusion/physical-plan/src/recursive_query.rs
+++ b/datafusion/physical-plan/src/recursive_query.rs
@@ -308,9 +308,16 @@ impl RecursiveQueryStream {
         // Downstream plans should not expect any partitioning.
         let partition = 0;
 
-        let recursive_plan = reset_plan_states(Arc::clone(&self.recursive_term))?;
-        self.recursive_stream =
-            Some(recursive_plan.execute(partition, Arc::clone(&self.task_context))?);
+        // Plans can have a state stored in the task context.
+        // To reuse a particular plan we need to fork a context to clear state.
+        // An example is `CrossJoinExec`, which loads the left table into memory and stores it in the context.
+        // However, if the data of the left table is derived from the work table, it will become outdated
+        // as the work table changes. When the next iteration executes this plan again, we must clear the left table.
+        let forked_ctx = self.task_context.fork();
+        self.recursive_stream = Some(
+            self.recursive_term
+                .execute(partition, Arc::new(forked_ctx))?,
+        );
         self.poll_next(cx)
     }
 }
@@ -336,26 +343,6 @@ fn assign_work_table(
             not_impl_err!("Recursive queries cannot be nested")
         } else {
             Ok(Transformed::no(plan))
-        }
-    })
-    .data()
-}
-
-/// Some plans will change their internal states after execution, making them unable to be executed again.
-/// This function uses `ExecutionPlan::with_new_children` to fork a new plan with initial states.
-///
-/// An example is `CrossJoinExec`, which loads the left table into memory and stores it in the plan.
-/// However, if the data of the left table is derived from the work table, it will become outdated
-/// as the work table changes. When the next iteration executes this plan again, we must clear the left table.
-fn reset_plan_states(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
-    plan.transform_up(|plan| {
-        // WorkTableExec's states have already been updated correctly.
-        if plan.as_any().is::<WorkTableExec>() {
-            Ok(Transformed::no(plan))
-        } else {
-            let new_plan = Arc::clone(&plan)
-                .with_new_children(plan.children().into_iter().cloned().collect())?;
-            Ok(Transformed::yes(new_plan))
         }
     })
     .data()


### PR DESCRIPTION
To reuse physical plan we need to move all shared resources from them. Some execs contain shared futures to initialize them lazy once across all partitions. For example, `HashJoinExec` contain a future that once collects all data from the build sie.

This patch moves such resources to the task context. Now each plan can save to the task context its own state to reuse across partitions.

