### PR TITLE
push down filter: extend a projection if some pushed filters are unsupported

### DIFF
--- a/datafusion/sql/src/parser.rs
+++ b/datafusion/sql/src/parser.rs
@@ -279,15 +279,14 @@ impl<'a> DFParser<'a> {
         sql: &str,
         dialect: &'a dyn Dialect,
     ) -> Result<Self, ParserError> {
-        let tokens = Tokenizer::new(dialect, sql).into_tokens().collect::<Result<_, _>>()?;
+        let tokens = Tokenizer::new(dialect, sql)
+            .into_tokens()
+            .collect::<Result<_, _>>()?;
         Ok(Self::from_dialect_and_tokens(dialect, tokens))
     }
 
     /// Create a new parser from specified dialect and tokens.
-    pub fn from_dialect_and_tokens(
-        dialect: &'a dyn Dialect,
-        tokens: Vec<Token>,
-    ) -> Self {
+    pub fn from_dialect_and_tokens(dialect: &'a dyn Dialect, tokens: Vec<Token>) -> Self {
         let parser = Parser::new(dialect).with_tokens(tokens);
         DFParser { parser }
     }


### PR DESCRIPTION
Consider the next scenario:

1. `supports_filters_pushdown` returns `Exact` on some filter, e.g. "a = 1", where column "a" is not required by the query projection.

2. "a" is removed from the table provider projection by "optimize projection" rule.

3. `supports_filters_pushdown` changes a decision and returns `Inexact` on this filter the next time. For example, input filters were changed and it prefers to use a new one.

4. "a" is not returned to the table provider projection which leads to filter that references a column which is not a part of the schema.

This patch fixes this issue introducing the next logic within a filter push-down rule:

1. Collect columns that are not used in the current table provider projection, but required for filter expressions. Call it `additional_projection`.

2. If `additional_projection` is empty -- leave all as it was before.

3. Otherwise extend a table provider projection and wrap a plan with an additional projection node to preserve schema used prior to this rule.

