### PR TITLE
expressions: make unknown column distinguishable

### DIFF
--- a/datafusion/physical-expr/src/expressions/unknown_column.rs
+++ b/datafusion/physical-expr/src/expressions/unknown_column.rs
@@ -51,7 +51,7 @@ impl UnKnownColumn {
 
 impl std::fmt::Display for UnKnownColumn {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.name)
+        write!(f, "?{}", self.name)
     }
 }
 


### PR DESCRIPTION
This patch makes "UnKnownColumn" expression distinguishable from actual "Column" expression to have an ability to compare them in planning tests. For now "UnKnownColumn" string representation is started from `?` symbol, for example, `partitioning=Hash([`?a@0`], 1)`.

