### PR TITLE
Resolve physical placeholders

### DIFF
--- a/datafusion/core/tests/physical_optimizer/mod.rs
+++ b/datafusion/core/tests/physical_optimizer/mod.rs
@@ -30,6 +30,8 @@ mod join_selection;
 mod limit_pushdown;
 mod limited_distinct_aggregation;
 mod partition_statistics;
+#[expect(clippy::needless_pass_by_value)]
+mod physical_expr_resolver;
 mod projection_pushdown;
 mod pushdown_sort;
 mod replace_with_order_preserving_variants;

--- a/datafusion/core/tests/physical_optimizer/physical_expr_resolver.rs
+++ b/datafusion/core/tests/physical_optimizer/physical_expr_resolver.rs
@@ -1,0 +1,276 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Integration tests for [`PhysicalExprResolver`] optimizer rule.
+
+use std::{collections::HashMap, sync::Arc};
+
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use datafusion::config::ConfigOptions;
+use datafusion_common::{ParamValues, Result, ScalarValue};
+use datafusion_execution::TaskContext;
+use datafusion_expr::Operator;
+use datafusion_physical_expr::{
+    Partitioning,
+    expressions::{BinaryExpr, col, lit, placeholder},
+};
+use datafusion_physical_optimizer::{
+    PhysicalOptimizerRule, physical_expr_resolver::PhysicalExprResolver,
+};
+use datafusion_physical_plan::{
+    ExecutionPlan, filter::FilterExec, get_plan_string,
+    plan_transformer::TransformPlanExec, repartition::RepartitionExec,
+};
+
+use crate::physical_optimizer::test_utils::{
+    coalesce_partitions_exec, global_limit_exec, resolve_placeholders_exec, stream_exec,
+};
+
+fn create_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("c1", DataType::Int32, true),
+        Field::new("c2", DataType::Int32, true),
+        Field::new("c3", DataType::Int32, true),
+    ]))
+}
+
+fn filter_exec(
+    schema: SchemaRef,
+    input: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    Ok(Arc::new(FilterExec::try_new(
+        Arc::new(BinaryExpr::new(
+            col("c3", schema.as_ref()).unwrap(),
+            Operator::Gt,
+            lit(0),
+        )),
+        input,
+    )?))
+}
+
+fn filter_exec_with_placeholders(
+    schema: SchemaRef,
+    input: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    Ok(Arc::new(FilterExec::try_new(
+        Arc::new(BinaryExpr::new(
+            col("c3", schema.as_ref()).unwrap(),
+            Operator::Gt,
+            placeholder("$foo", DataType::Int32),
+        )),
+        input,
+    )?))
+}
+
+fn repartition_exec(
+    streaming_table: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    Ok(Arc::new(RepartitionExec::try_new(
+        streaming_table,
+        Partitioning::RoundRobinBatch(8),
+    )?))
+}
+
+#[test]
+fn test_noop_if_no_placeholders_found() -> Result<()> {
+    let schema = create_schema();
+    let streaming_table = stream_exec(&schema);
+    let repartition = repartition_exec(streaming_table)?;
+    let filter = filter_exec(schema, repartition)?;
+    let coalesce_partitions = coalesce_partitions_exec(filter);
+    let plan = global_limit_exec(coalesce_partitions, 0, Some(5));
+
+    let initial = get_plan_string(&plan);
+    let expected_initial = [
+        "GlobalLimitExec: skip=0, fetch=5",
+        "  CoalescePartitionsExec",
+        "    FilterExec: c3@2 > 0",
+        "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+        "        StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true",
+    ];
+
+    assert_eq!(initial, expected_initial);
+
+    let after_optimize = PhysicalExprResolver::new_post_optimization()
+        .optimize(plan, &ConfigOptions::new())?;
+
+    let optimized_plan_string = get_plan_string(&after_optimize);
+    assert_eq!(initial, optimized_plan_string);
+
+    Ok(())
+}
+
+#[test]
+fn test_wrap_plan_with_transformer() -> Result<()> {
+    let schema = create_schema();
+    let streaming_table = stream_exec(&schema);
+    let repartition = repartition_exec(streaming_table)?;
+    let filter = filter_exec_with_placeholders(schema, repartition)?;
+    let coalesce_partitions = coalesce_partitions_exec(filter);
+    let plan = global_limit_exec(coalesce_partitions, 0, Some(5));
+
+    let initial = get_plan_string(&plan);
+    let expected_initial = [
+        "GlobalLimitExec: skip=0, fetch=5",
+        "  CoalescePartitionsExec",
+        "    FilterExec: c3@2 > $foo",
+        "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+        "        StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true",
+    ];
+
+    assert_eq!(initial, expected_initial);
+
+    let after_optimize = PhysicalExprResolver::new_post_optimization()
+        .optimize(plan, &ConfigOptions::new())?;
+
+    let expected_optimized = [
+        "TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]",
+        "  GlobalLimitExec: skip=0, fetch=5",
+        "    CoalescePartitionsExec",
+        "      FilterExec: c3@2 > $foo",
+        "        RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+        "          StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true",
+    ];
+
+    let optimized_plan_string = get_plan_string(&after_optimize);
+    assert_eq!(optimized_plan_string, expected_optimized);
+
+    let transformer = after_optimize
+        .as_ref()
+        .as_any()
+        .downcast_ref::<TransformPlanExec>()
+        .expect("should downcast");
+
+    let param_values = ParamValues::Map(HashMap::from_iter([(
+        "foo".to_string(),
+        ScalarValue::Int32(Some(100)).into(),
+    )]));
+
+    let ctx = Arc::new(TaskContext::default().with_param_values(param_values));
+    let resolved_plan = transformer.transform(&ctx)?;
+    let resolved_plan_string = get_plan_string(&resolved_plan);
+    let expected_resolved = [
+        "GlobalLimitExec: skip=0, fetch=5",
+        "  CoalescePartitionsExec",
+        "    FilterExec: c3@2 > 100",
+        "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+        "        StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true",
+    ];
+
+    assert_eq!(resolved_plan_string, expected_resolved);
+
+    Ok(())
+}
+
+#[test]
+fn test_remove_useless_transformers() -> Result<()> {
+    let schema = create_schema();
+    let streaming_table = stream_exec(&schema);
+    let repartition = repartition_exec(streaming_table)?;
+    let filter = filter_exec(schema, repartition)?;
+    let transformer = resolve_placeholders_exec(filter);
+    let coalesce_partitions = coalesce_partitions_exec(transformer);
+    let global_limit = global_limit_exec(coalesce_partitions, 0, Some(5));
+    let plan = resolve_placeholders_exec(global_limit);
+
+    let initial = get_plan_string(&plan);
+    let expected_initial = [
+        "TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=0]",
+        "  GlobalLimitExec: skip=0, fetch=5",
+        "    CoalescePartitionsExec",
+        "      TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=0]",
+        "        FilterExec: c3@2 > 0",
+        "          RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+        "            StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true",
+    ];
+
+    assert_eq!(initial, expected_initial);
+
+    let after_optimize =
+        PhysicalExprResolver::new().optimize(plan, &ConfigOptions::new())?;
+
+    let expected_optimized = [
+        "GlobalLimitExec: skip=0, fetch=5",
+        "  CoalescePartitionsExec",
+        "    FilterExec: c3@2 > 0",
+        "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+        "        StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true",
+    ];
+
+    let optimized_plan_string = get_plan_string(&after_optimize);
+    assert_eq!(optimized_plan_string, expected_optimized);
+
+    Ok(())
+}
+
+#[test]
+fn test_combine_transformers() -> Result<()> {
+    let schema = create_schema();
+    let streaming_table = stream_exec(&schema);
+    let repartition = repartition_exec(streaming_table)?;
+    let transformer = resolve_placeholders_exec(repartition);
+    let filter = filter_exec_with_placeholders(schema, transformer)?;
+    let transformer = resolve_placeholders_exec(filter);
+    let coalesce_partitions = coalesce_partitions_exec(transformer);
+    let global_limit = global_limit_exec(coalesce_partitions, 0, Some(5));
+    let plan = resolve_placeholders_exec(global_limit);
+
+    let initial = get_plan_string(&plan);
+    let expected_initial = [
+        "TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=0]",
+        "  GlobalLimitExec: skip=0, fetch=5",
+        "    CoalescePartitionsExec",
+        "      TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]",
+        "        FilterExec: c3@2 > $foo",
+        "          TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=0]",
+        "            RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+        "              StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true",
+    ];
+
+    assert_eq!(initial, expected_initial);
+
+    let after_pre_optimization =
+        PhysicalExprResolver::new().optimize(plan, &ConfigOptions::new())?;
+
+    let expected_optimized = [
+        "GlobalLimitExec: skip=0, fetch=5",
+        "  CoalescePartitionsExec",
+        "    FilterExec: c3@2 > $foo",
+        "      RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+        "        StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true",
+    ];
+
+    let optimized_plan_string = get_plan_string(&after_pre_optimization);
+    assert_eq!(optimized_plan_string, expected_optimized);
+
+    let after_post_optimization = PhysicalExprResolver::new_post_optimization()
+        .optimize(after_pre_optimization, &ConfigOptions::new())?;
+
+    let expected_optimized = [
+        "TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]",
+        "  GlobalLimitExec: skip=0, fetch=5",
+        "    CoalescePartitionsExec",
+        "      FilterExec: c3@2 > $foo",
+        "        RepartitionExec: partitioning=RoundRobinBatch(8), input_partitions=1",
+        "          StreamingTableExec: partition_sizes=1, projection=[c1, c2, c3], infinite_source=true",
+    ];
+
+    let optimized_plan_string = get_plan_string(&after_post_optimization);
+    assert_eq!(optimized_plan_string, expected_optimized);
+
+    Ok(())
+}

--- a/datafusion/core/tests/physical_optimizer/test_utils.rs
+++ b/datafusion/core/tests/physical_optimizer/test_utils.rs
@@ -59,6 +59,9 @@ use datafusion_physical_plan::filter::FilterExec;
 use datafusion_physical_plan::joins::utils::{JoinFilter, JoinOn};
 use datafusion_physical_plan::joins::{HashJoinExec, PartitionMode, SortMergeJoinExec};
 use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
+use datafusion_physical_plan::plan_transformer::{
+    ResolvePlaceholdersRule, TransformPlanExec,
+};
 use datafusion_physical_plan::projection::{ProjectionExec, ProjectionExpr};
 use datafusion_physical_plan::repartition::RepartitionExec;
 use datafusion_physical_plan::sorts::sort::SortExec;
@@ -391,6 +394,15 @@ pub fn projection_exec(
         .map(|(expr, alias)| ProjectionExpr { expr, alias })
         .collect();
     Ok(Arc::new(ProjectionExec::try_new(proj_exprs, input)?))
+}
+
+pub fn resolve_placeholders_exec(
+    input: Arc<dyn ExecutionPlan>,
+) -> Arc<dyn ExecutionPlan> {
+    Arc::new(
+        TransformPlanExec::try_new(input, vec![Box::new(ResolvePlaceholdersRule::new())])
+            .unwrap(),
+    )
 }
 
 /// A test [`ExecutionPlan`] whose requirements can be configured.

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 use super::*;
 use datafusion_common::{ParamValues, ScalarValue, metadata::ScalarAndMetadata};
+use datafusion_execution::TaskContext;
 use insta::assert_snapshot;
 
 #[tokio::test]
@@ -429,5 +430,145 @@ async fn test_select_cast_date_literal_to_timestamp_overflow() -> Result<()> {
         err.to_string(),
         "Cannot cast Date32 value 2932896 to Timestamp(ns): converted value exceeds the representable i64 range"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_resolve_window_function() -> Result<()> {
+    let ctx = SessionContext::new();
+    let batch = record_batch!(("id", Int32, [1, 2]), ("name", Utf8, ["Alex", "Bob"]))?;
+    ctx.register_batch("t1", batch)?;
+
+    let plan = ctx
+        .sql("SELECT id, SUM(id + $1) OVER (PARTITION BY name ORDER BY id) FROM t1")
+        .await?
+        .create_physical_plan()
+        .await?;
+
+    let param_values = ParamValues::List(vec![ScalarValue::Int32(Some(100)).into()]);
+    let task_ctx = Arc::new(TaskContext::from(&ctx).with_param_values(param_values));
+    let batches = collect(plan, task_ctx).await?;
+
+    assert_snapshot!(batches_to_sort_string(&batches), @r"
+    +----+--------------------------------------------------------------------------------------------------------------------------+
+    | id | sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW |
+    +----+--------------------------------------------------------------------------------------------------------------------------+
+    | 1  | 101                                                                                                                      |
+    | 2  | 102                                                                                                                      |
+    +----+--------------------------------------------------------------------------------------------------------------------------+
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_resolve_join() -> Result<()> {
+    let ctx = SessionContext::new();
+    let batch_1 = record_batch!(
+        ("id", Int32, [1, 2]),
+        ("name", Utf8, ["Alex", "Bob"]),
+        ("age", Int32, [30, 40])
+    )?;
+
+    let batch_2 = record_batch!(
+        ("id", Int32, [10, 20]),
+        ("name", Utf8, ["Carol", "David"]),
+        ("age", Int32, [35, 45])
+    )?;
+
+    ctx.register_batch("t1", batch_1)?;
+    ctx.register_batch("t2", batch_2)?;
+
+    let plan = ctx
+        .sql("SELECT t1.name, t2.age FROM t1 JOIN t2 ON t1.id + $1 = t2.id;")
+        .await?
+        .create_physical_plan()
+        .await?;
+
+    let param_values = ParamValues::List(vec![ScalarValue::Int32(Some(8)).into()]);
+    let task_ctx = Arc::new(TaskContext::from(&ctx).with_param_values(param_values));
+    let batches = collect(plan, task_ctx).await?;
+
+    assert_snapshot!(batches_to_sort_string(&batches), @r"
+    +------+-----+
+    | name | age |
+    +------+-----+
+    | Bob  | 35  |
+    +------+-----+
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_resolve_cast() -> Result<()> {
+    let ctx = SessionContext::new();
+    let plan = ctx
+        .sql("SELECT CAST($1 as INT)")
+        .await?
+        .create_physical_plan()
+        .await?;
+
+    let param_values = ParamValues::List(vec![
+        ScalarValue::Utf8(Some("not a number".to_string())).into(),
+    ]);
+
+    let task_ctx = Arc::new(TaskContext::from(&ctx).with_param_values(param_values));
+    let result = collect(Arc::clone(&plan), task_ctx).await;
+    assert!(result.is_err());
+
+    let param_values =
+        ParamValues::List(vec![ScalarValue::Utf8(Some("200".to_string())).into()]);
+    let task_ctx = Arc::new(TaskContext::from(&ctx).with_param_values(param_values));
+    let batches = collect(plan, task_ctx).await?;
+
+    assert_snapshot!(batches_to_sort_string(&batches), @r"
+    +-----+
+    | $1  |
+    +-----+
+    | 200 |
+    +-----+
+    ");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_resolve_try_cast() -> Result<()> {
+    let ctx = SessionContext::new();
+    let plan = ctx
+        .sql("SELECT TRY_CAST($1 as INT)")
+        .await?
+        .create_physical_plan()
+        .await?;
+
+    let param_values = ParamValues::List(vec![
+        ScalarValue::Utf8(Some("not a number".to_string())).into(),
+    ]);
+
+    let task_ctx = Arc::new(TaskContext::from(&ctx).with_param_values(param_values));
+    let batches = collect(Arc::clone(&plan), task_ctx).await?;
+
+    assert_snapshot!(batches_to_sort_string(&batches), @r"
+    +----+
+    | $1 |
+    +----+
+    |    |
+    +----+
+    ");
+
+    let param_values =
+        ParamValues::List(vec![ScalarValue::Utf8(Some("200".to_string())).into()]);
+    let task_ctx = Arc::new(TaskContext::from(&ctx).with_param_values(param_values));
+    let batches = collect(plan, task_ctx).await?;
+
+    assert_snapshot!(batches_to_sort_string(&batches), @r"
+    +-----+
+    | $1  |
+    +-----+
+    | 200 |
+    +-----+
+    ");
+
     Ok(())
 }

--- a/datafusion/execution/src/task.rs
+++ b/datafusion/execution/src/task.rs
@@ -19,7 +19,9 @@ use crate::{
     config::SessionConfig, memory_pool::MemoryPool, registry::FunctionRegistry,
     runtime_env::RuntimeEnv,
 };
-use datafusion_common::{Result, internal_datafusion_err, plan_datafusion_err};
+use datafusion_common::{
+    ParamValues, Result, internal_datafusion_err, plan_datafusion_err,
+};
 use datafusion_expr::planner::ExprPlanner;
 use datafusion_expr::{AggregateUDF, ScalarUDF, WindowUDF};
 use std::collections::HashSet;
@@ -48,6 +50,8 @@ pub struct TaskContext {
     window_functions: HashMap<String, Arc<WindowUDF>>,
     /// Runtime environment associated with this task context
     runtime: Arc<RuntimeEnv>,
+    /// External query parameters
+    param_values: Option<ParamValues>,
 }
 
 impl Default for TaskContext {
@@ -63,6 +67,7 @@ impl Default for TaskContext {
             aggregate_functions: HashMap::new(),
             window_functions: HashMap::new(),
             runtime,
+            param_values: None,
         }
     }
 }
@@ -90,6 +95,7 @@ impl TaskContext {
             aggregate_functions,
             window_functions,
             runtime,
+            param_values: None,
         }
     }
 
@@ -118,6 +124,11 @@ impl TaskContext {
         Arc::clone(&self.runtime)
     }
 
+    /// Return param values associated with this [`TaskContext`]
+    pub fn param_values(&self) -> &Option<ParamValues> {
+        &self.param_values
+    }
+
     pub fn scalar_functions(&self) -> &HashMap<String, Arc<ScalarUDF>> {
         &self.scalar_functions
     }
@@ -139,6 +150,12 @@ impl TaskContext {
     /// Update the [`RuntimeEnv`]
     pub fn with_runtime(mut self, runtime: Arc<RuntimeEnv>) -> Self {
         self.runtime = runtime;
+        self
+    }
+
+    /// Update the [`ParamValues`]
+    pub fn with_param_values(mut self, param_values: ParamValues) -> Self {
+        self.param_values = Some(param_values);
         self
     }
 }

--- a/datafusion/physical-expr/src/expressions/mod.rs
+++ b/datafusion/physical-expr/src/expressions/mod.rs
@@ -32,6 +32,7 @@ mod literal;
 mod negative;
 mod no_op;
 mod not;
+mod placeholder;
 mod try_cast;
 mod unknown_column;
 
@@ -54,5 +55,6 @@ pub use literal::{Literal, lit};
 pub use negative::{NegativeExpr, negative};
 pub use no_op::NoOp;
 pub use not::{NotExpr, not};
+pub use placeholder::{PlaceholderExpr, has_placeholders, placeholder};
 pub use try_cast::{TryCastExpr, try_cast};
 pub use unknown_column::UnKnownColumn;

--- a/datafusion/physical-expr/src/expressions/placeholder.rs
+++ b/datafusion/physical-expr/src/expressions/placeholder.rs
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Placeholder expression.
+
+use std::{
+    any::Any,
+    fmt::{self, Formatter},
+    sync::Arc,
+};
+
+use arrow::{
+    array::RecordBatch,
+    datatypes::{DataType, Field, FieldRef, Schema},
+};
+use datafusion_common::{
+    DataFusionError, Result, exec_datafusion_err, tree_node::TreeNode,
+};
+use datafusion_expr::ColumnarValue;
+use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
+use std::hash::Hash;
+
+/// Physical expression representing a placeholder parameter (e.g., $1, $2, or named parameters) in
+/// the physical plan.
+///
+/// This expression serves as a placeholder that will be resolved to a literal value during
+/// execution. It should not be evaluated directly.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct PlaceholderExpr {
+    /// Placeholder id, e.g. $1 or $a.
+    pub id: String,
+    /// Derived from expression where placeholder is met.
+    pub field: Option<FieldRef>,
+}
+
+impl PlaceholderExpr {
+    /// Create a new placeholder expression.
+    pub fn new(id: String, data_type: DataType) -> Self {
+        let field = Arc::new(Field::new("", data_type, true));
+        Self::new_with_field(id, field)
+    }
+
+    /// Create a new placeholders expression from a field.
+    pub fn new_with_field(id: String, field: FieldRef) -> Self {
+        Self {
+            id,
+            field: Some(field),
+        }
+    }
+
+    /// Create a new placeholder expression without a specified data type.
+    pub fn new_without_data_type(id: String) -> Self {
+        Self { id, field: None }
+    }
+
+    fn execution_error(&self) -> DataFusionError {
+        exec_datafusion_err!(
+            "Placeholder '{}' was not provided a value for execution.",
+            self.id
+        )
+    }
+}
+
+/// Create a placeholder expression.
+pub fn placeholder<I: Into<String>>(id: I, data_type: DataType) -> Arc<dyn PhysicalExpr> {
+    Arc::new(PlaceholderExpr::new(id.into(), data_type))
+}
+
+/// Returns `true` if expression has placeholders.
+pub fn has_placeholders(expr: &Arc<dyn PhysicalExpr>) -> bool {
+    expr.exists(|e| Ok(e.as_any().is::<PlaceholderExpr>()))
+        .expect("do not return errors")
+}
+
+impl fmt::Display for PlaceholderExpr {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{}", self.id)
+    }
+}
+
+impl PhysicalExpr for PlaceholderExpr {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn return_field(&self, _input_schema: &Schema) -> Result<FieldRef> {
+        self.field
+            .as_ref()
+            .map(Arc::clone)
+            .ok_or_else(|| self.execution_error())
+    }
+
+    fn evaluate(&self, _batch: &RecordBatch) -> Result<ColumnarValue> {
+        Err(self.execution_error())
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        assert!(children.is_empty());
+        Ok(self)
+    }
+
+    fn fmt_sql(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}

--- a/datafusion/physical-expr/src/planner.rs
+++ b/datafusion/physical-expr/src/planner.rs
@@ -20,10 +20,10 @@ use std::sync::Arc;
 use crate::ScalarFunctionExpr;
 use crate::{
     PhysicalExpr,
-    expressions::{self, Column, Literal, binary, like, similar_to},
+    expressions::{self, Column, Literal, PlaceholderExpr, binary, like, similar_to},
 };
 
-use arrow::datatypes::Schema;
+use arrow::datatypes::{DataType, Schema};
 use datafusion_common::config::ConfigOptions;
 use datafusion_common::metadata::FieldMetadata;
 use datafusion_common::{
@@ -288,16 +288,28 @@ pub fn create_physical_expr(
                 };
             Ok(expressions::case(expr, when_then_expr, else_expr)?)
         }
-        Expr::Cast(Cast { expr, data_type }) => expressions::cast(
-            create_physical_expr(expr, input_dfschema, execution_props)?,
-            input_schema,
-            data_type.clone(),
-        ),
-        Expr::TryCast(TryCast { expr, data_type }) => expressions::try_cast(
-            create_physical_expr(expr, input_dfschema, execution_props)?,
-            input_schema,
-            data_type.clone(),
-        ),
+        Expr::Cast(Cast { expr, data_type }) => {
+            let mut expr = create_physical_expr(expr, input_dfschema, execution_props)?;
+            if let Some(placeholder) = expr.as_any().downcast_ref::<PlaceholderExpr>()
+                && placeholder.field.is_none()
+            {
+                expr = expressions::placeholder(&placeholder.id, data_type.clone());
+            }
+
+            expressions::cast(expr, input_schema, data_type.clone())
+        }
+        Expr::TryCast(TryCast { expr, data_type }) => {
+            let mut expr = create_physical_expr(expr, input_dfschema, execution_props)?;
+            if let Some(placeholder) = expr.as_any().downcast_ref::<PlaceholderExpr>()
+                && placeholder.field.is_none()
+            {
+                // To maintain try_cast behavior, we initially resolve the placeholder with the
+                // Utf8 data type.
+                expr = expressions::placeholder(&placeholder.id, DataType::Utf8);
+            }
+
+            expressions::try_cast(expr, input_schema, data_type.clone())
+        }
         Expr::Not(expr) => {
             expressions::not(create_physical_expr(expr, input_dfschema, execution_props)?)
         }
@@ -381,9 +393,13 @@ pub fn create_physical_expr(
                 expressions::in_list(value_expr, list_exprs, negated, input_schema)
             }
         },
-        Expr::Placeholder(Placeholder { id, .. }) => {
-            exec_err!("Placeholder '{id}' was not provided a value for execution.")
-        }
+        Expr::Placeholder(Placeholder { id, field }) => match field {
+            Some(field) => Ok(Arc::new(PlaceholderExpr::new_with_field(
+                id.clone(),
+                Arc::clone(field),
+            ))),
+            None => Ok(Arc::new(PlaceholderExpr::new_without_data_type(id.clone()))),
+        },
         other => {
             not_impl_err!("Physical plan does not support logical expression {other:?}")
         }

--- a/datafusion/physical-expr/src/simplifier/const_evaluator.rs
+++ b/datafusion/physical-expr/src/simplifier/const_evaluator.rs
@@ -27,7 +27,7 @@ use datafusion_common::{Result, ScalarValue};
 use datafusion_expr_common::columnar_value::ColumnarValue;
 
 use crate::PhysicalExpr;
-use crate::expressions::{Column, Literal};
+use crate::expressions::{Column, Literal, PlaceholderExpr};
 
 /// Simplify expressions that consist only of literals by evaluating them.
 ///
@@ -81,7 +81,10 @@ fn can_evaluate_as_constant(expr: &Arc<dyn PhysicalExpr>) -> bool {
     let mut can_evaluate = true;
 
     expr.apply(|e| {
-        if e.as_any().is::<Column>() || e.is_volatile_node() {
+        if e.as_any().is::<Column>()
+            || e.is_volatile_node()
+            || e.as_any().is::<PlaceholderExpr>()
+        {
             can_evaluate = false;
             Ok(TreeNodeRecursion::Stop)
         } else {

--- a/datafusion/physical-optimizer/src/filter_pushdown.rs
+++ b/datafusion/physical-optimizer/src/filter_pushdown.rs
@@ -38,6 +38,7 @@ use crate::PhysicalOptimizerRule;
 use datafusion_common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion_common::{Result, assert_eq_or_internal_err, config::ConfigOptions};
 use datafusion_physical_expr::PhysicalExpr;
+use datafusion_physical_expr::expressions::has_placeholders;
 use datafusion_physical_expr_common::physical_expr::is_volatile;
 use datafusion_physical_plan::filter_pushdown::{
     ChildFilterPushdownResult, ChildPushdownResult, FilterPushdownPhase,
@@ -486,16 +487,24 @@ fn push_down_filters(
         // currently. `self_filters` are the predicates which are provided by the current node,
         // and tried to be pushed down over the child similarly.
 
-        // Filter out self_filters that contain volatile expressions and track indices
-        let self_filtered = FilteredVec::new(&self_filters, allow_pushdown_for_expr);
+        let child_supports_exprs_replacement = child.physical_expressions().is_some();
+
+        // Filter out self_filters that contain volatile expressions or unsupported placeholders
+        // and track indices.
+        let self_filtered = FilteredVec::new(&self_filters, |expr| {
+            allow_pushdown_for_expr(expr)
+                && (child_supports_exprs_replacement || !has_placeholders(expr))
+        });
 
         let num_self_filters = self_filtered.len();
         let mut all_predicates = self_filtered.items().to_vec();
 
         // Apply second filter pass: collect indices of parent filters that can be pushed down
-        let parent_filters_for_child = parent_filtered
-            .chain_filter_slice(&parent_filters, |filter| {
+        let parent_filters_for_child =
+            parent_filtered.chain_filter_slice(&parent_filters, |filter| {
                 matches!(filter.discriminant, PushedDown::Yes)
+                    && (child_supports_exprs_replacement
+                        || !has_placeholders(&filter.predicate))
             });
 
         // Add the filtered parent predicates to all_predicates

--- a/datafusion/physical-optimizer/src/lib.rs
+++ b/datafusion/physical-optimizer/src/lib.rs
@@ -37,6 +37,7 @@ pub mod limit_pushdown_past_window;
 pub mod limited_distinct_aggregation;
 pub mod optimizer;
 pub mod output_requirements;
+pub mod physical_expr_resolver;
 pub mod projection_pushdown;
 pub use datafusion_pruning as pruning;
 pub mod pushdown_sort;

--- a/datafusion/physical-optimizer/src/optimizer.rs
+++ b/datafusion/physical-optimizer/src/optimizer.rs
@@ -30,6 +30,7 @@ use crate::join_selection::JoinSelection;
 use crate::limit_pushdown::LimitPushdown;
 use crate::limited_distinct_aggregation::LimitedDistinctAggregation;
 use crate::output_requirements::OutputRequirements;
+use crate::physical_expr_resolver::PhysicalExprResolver;
 use crate::projection_pushdown::ProjectionPushdown;
 use crate::sanity_checker::SanityCheckPlan;
 use crate::topk_aggregation::TopKAggregation;
@@ -86,6 +87,8 @@ impl PhysicalOptimizer {
             // If there is a output requirement of the query, make sure that
             // this information is not lost across different rules during optimization.
             Arc::new(OutputRequirements::new_add_mode()),
+            // This rule removes all existing `TransformPlanExec` nodes from the plan tree.
+            Arc::new(PhysicalExprResolver::new()),
             Arc::new(AggregateStatistics::new()),
             // Statistics-based join selection will change the Auto mode to a real join implementation,
             // like collect left, or hash join, or future sort merge join, which will influence the
@@ -145,6 +148,10 @@ impl PhysicalOptimizer {
             // PushdownSort: Detect sorts that can be pushed down to data sources.
             Arc::new(PushdownSort::new()),
             Arc::new(EnsureCooperative::new()),
+            // This rule prepares the physical plan for placeholder resolution by wrapping it in a
+            // `TransformPlanExec` with a `ResolvePlaceholdersRule` if it contains any unresolved
+            // placeholders.
+            Arc::new(PhysicalExprResolver::new_post_optimization()),
             // This FilterPushdown handles dynamic filters that may have references to the source ExecutionPlan.
             // Therefore it should be run at the end of the optimization process since any changes to the plan may break the dynamic filter's references.
             // See `FilterPushdownPhase` for more details.

--- a/datafusion/physical-optimizer/src/physical_expr_resolver.rs
+++ b/datafusion/physical-optimizer/src/physical_expr_resolver.rs
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! [`PhysicalExprResolver`] ensures that the physical plan is prepared for placeholder resolution
+//! by wrapping it in a [`TransformPlanExec`] with a [`ResolvePlaceholdersRule`] if the plan
+//! contains any unresolved placeholders. The actual resolution happens during execution.
+
+use std::sync::Arc;
+
+use datafusion_common::{
+    Result,
+    config::ConfigOptions,
+    tree_node::{Transformed, TreeNode},
+};
+use datafusion_physical_plan::{
+    ExecutionPlan,
+    plan_transformer::{ResolvePlaceholdersRule, TransformPlanExec},
+};
+
+use crate::PhysicalOptimizerRule;
+
+/// The phase in which the [`PhysicalExprResolver`] rule is applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhysicalExprResolverPhase {
+    /// Optimization that happens before most other optimizations.
+    /// This optimization removes all [`TransformPlanExec`] execution plans from the plan
+    /// tree.
+    Pre,
+    /// Optimization that happens after most other optimizations.
+    /// This optimization checks for the presence of placeholders in the optimized plan, and if
+    /// they are present, wraps the plan in a [`TransformPlanExec`] with a [`ResolvePlaceholdersRule`].
+    Post,
+}
+
+/// Physical optimizer rule that prepares the plan for placeholder resolution during execution.
+#[derive(Debug)]
+pub struct PhysicalExprResolver {
+    phase: PhysicalExprResolverPhase,
+}
+
+impl PhysicalExprResolver {
+    /// Creates a new [`PhysicalExprResolver`] optimizer rule that runs in the pre-optimization
+    /// phase. In this phase, the rule removes any existing [`TransformPlanExec`] from the
+    /// plan tree.
+    pub fn new() -> Self {
+        Self {
+            phase: PhysicalExprResolverPhase::Pre,
+        }
+    }
+
+    /// Creates a new [`PhysicalExprResolver`] optimizer rule that runs in the post-optimization
+    /// phase. In this phase, the rule wraps the physical plan in a [`TransformPlanExec`] with a
+    /// [`ResolvePlaceholdersRule`] if the plan contains any unresolved placeholders.
+    pub fn new_post_optimization() -> Self {
+        Self {
+            phase: PhysicalExprResolverPhase::Post,
+        }
+    }
+}
+
+impl Default for PhysicalExprResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PhysicalOptimizerRule for PhysicalExprResolver {
+    fn name(&self) -> &str {
+        match self.phase {
+            PhysicalExprResolverPhase::Pre => "PhysicalExprResolver",
+            PhysicalExprResolverPhase::Post => "PhysicalExprResolver(Post)",
+        }
+    }
+
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match self.phase {
+            PhysicalExprResolverPhase::Pre => plan
+                .transform_up(|plan| {
+                    if let Some(plan) = plan.as_any().downcast_ref::<TransformPlanExec>()
+                    {
+                        Ok(Transformed::yes(Arc::clone(plan.input())))
+                    } else {
+                        Ok(Transformed::no(plan))
+                    }
+                })
+                .map(|t| t.data),
+            PhysicalExprResolverPhase::Post => {
+                if let Some(transformer) =
+                    plan.as_any().downcast_ref::<TransformPlanExec>()
+                {
+                    let resolves_placeholders =
+                        transformer.has_rule::<ResolvePlaceholdersRule>();
+
+                    if resolves_placeholders {
+                        Ok(plan)
+                    } else {
+                        transformer
+                            .add_rule(Box::new(ResolvePlaceholdersRule::new()))
+                            .map(|r| Arc::new(r) as Arc<_>)
+                    }
+                } else {
+                    let transformer = TransformPlanExec::try_new(
+                        plan,
+                        vec![Box::new(ResolvePlaceholdersRule::new())],
+                    )?;
+
+                    if transformer.plans_to_transform() > 0 {
+                        Ok(Arc::new(transformer))
+                    } else {
+                        Ok(Arc::clone(transformer.input()))
+                    }
+                }
+            }
+        }
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}

--- a/datafusion/physical-plan/Cargo.toml
+++ b/datafusion/physical-plan/Cargo.toml
@@ -102,3 +102,7 @@ name = "sort_preserving_merge"
 harness = false
 name = "aggregate_vectorized"
 required-features = ["test_utils"]
+
+[[bench]]
+harness = false
+name = "plan_transformer"

--- a/datafusion/physical-plan/benches/plan_transformer.rs
+++ b/datafusion/physical-plan/benches/plan_transformer.rs
@@ -1,0 +1,313 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow_schema::Schema;
+use criterion::measurement::WallTime;
+use datafusion_common::Result;
+use datafusion_common::tree_node::{
+    Transformed, TreeNode, TreeNodeRecursion, TreeNodeRewriter,
+};
+use datafusion_execution::TaskContext;
+use datafusion_physical_plan::ExecutionPlan;
+use datafusion_physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion_physical_plan::empty::EmptyExec;
+use datafusion_physical_plan::plan_transformer::{
+    ExecutionTransformationRule, TransformPlanExec,
+};
+
+use criterion::{BatchSize, BenchmarkGroup, Criterion, criterion_group, criterion_main};
+
+#[derive(Debug, Clone)]
+struct ResetAllRule {}
+
+impl ExecutionTransformationRule for ResetAllRule {
+    fn name(&self) -> &str {
+        "ResetAllRule"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn clone_box(&self) -> Box<dyn ExecutionTransformationRule> {
+        Box::new(self.clone())
+    }
+
+    fn matches(&mut self, _node: &Arc<dyn ExecutionPlan>) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn rewrite(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        _ctx: &TaskContext,
+    ) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
+        node.reset_state().map(Transformed::yes)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResetByNameRule {
+    node_name: String,
+}
+
+impl ExecutionTransformationRule for ResetByNameRule {
+    fn name(&self) -> &str {
+        "ResetByNameRule"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn clone_box(&self) -> Box<dyn ExecutionTransformationRule> {
+        Box::new(self.clone())
+    }
+
+    fn matches(&mut self, node: &Arc<dyn ExecutionPlan>) -> Result<bool> {
+        Ok(node.name() == self.node_name)
+    }
+
+    fn rewrite(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        _ctx: &TaskContext,
+    ) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
+        node.reset_state().map(Transformed::yes)
+    }
+}
+
+struct ResetAllRewriter;
+
+impl TreeNodeRewriter for ResetAllRewriter {
+    type Node = Arc<dyn ExecutionPlan>;
+
+    fn f_up(&mut self, node: Self::Node) -> Result<Transformed<Self::Node>> {
+        // This part is needed for handling nested rewriters.
+        if node.as_any().is::<MockRewriterExec>() {
+            return Ok(Transformed::new(node, false, TreeNodeRecursion::Jump));
+        }
+        node.reset_state().map(Transformed::yes)
+    }
+}
+
+struct ResetByNameRewriter {
+    node_name: String,
+}
+
+impl TreeNodeRewriter for ResetByNameRewriter {
+    type Node = Arc<dyn ExecutionPlan>;
+
+    fn f_up(&mut self, node: Self::Node) -> Result<Transformed<Self::Node>> {
+        // This part is needed for handling nested rewriters.
+        if node.as_any().is::<MockRewriterExec>() {
+            return Ok(Transformed::new(node, false, TreeNodeRecursion::Jump));
+        }
+
+        if node.name() == self.node_name {
+            node.reset_state().map(Transformed::yes)
+        } else {
+            Ok(Transformed::no(node))
+        }
+    }
+}
+
+struct MockRewriterExec {
+    input: Arc<dyn ExecutionPlan>,
+}
+
+impl MockRewriterExec {
+    fn execute(
+        &self,
+        rewriter: &mut impl TreeNodeRewriter<Node = Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let input = Arc::clone(&self.input);
+        input.rewrite(rewriter).map(|t| t.data)
+    }
+}
+
+fn create_deep_tree(depth: usize) -> Arc<dyn ExecutionPlan> {
+    let schema = Arc::new(Schema::empty());
+    let mut node: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+    for _ in 0..depth {
+        node = Arc::new(CoalescePartitionsExec::new(node));
+    }
+    node
+}
+
+fn nodes_amount(plan: &Arc<dyn ExecutionPlan>) -> usize {
+    let mut amount = 0;
+    plan.apply(|_| {
+        amount += 1;
+        Ok(TreeNodeRecursion::Continue)
+    })
+    .unwrap();
+    amount
+}
+
+fn benchmark_with_transformer_exec(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    batch_label: &str,
+    plan: &Arc<dyn ExecutionPlan>,
+    rules: &[Box<dyn ExecutionTransformationRule>],
+    batch_size: BatchSize,
+) {
+    let ctx = Arc::new(TaskContext::default());
+    let nodes_amount = nodes_amount(plan);
+
+    group.bench_function(
+        format!(
+            "transform_plan_exec_two_phases_{batch_label}_{nodes_amount}_nodes_{}_rule(s)",
+            rules.len()
+        ),
+        |b| {
+            b.iter_batched(
+                || {
+                    (
+                        Arc::clone(plan),
+                        rules.iter().map(|r| r.clone_box()).collect(),
+                    )
+                },
+                |(plan, rules)| {
+                    let transformer = TransformPlanExec::try_new(plan, rules).unwrap();
+                    transformer.transform(&ctx).unwrap();
+                },
+                batch_size,
+            )
+        },
+    );
+
+    group.bench_function(
+        format!(
+            "transform_plan_exec_second_phase_{batch_label}_{nodes_amount}_nodes_{}_rule(s)",
+            rules.len()
+        ),
+        |b| {
+            let plan = Arc::clone(plan);
+            let rules = rules.iter().map(|r| r.clone_box()).collect();
+            let transformer = Arc::new(TransformPlanExec::try_new(plan, rules).unwrap());
+
+            b.iter_batched(
+                || Arc::clone(&transformer),
+                |transformer| {
+                    transformer.transform(&ctx).unwrap();
+                },
+                batch_size,
+            )
+        },
+    );
+}
+
+fn benchmark_with_tree_node_rewriter(
+    group: &mut BenchmarkGroup<'_, WallTime>,
+    batch_label: &str,
+    plan: &Arc<dyn ExecutionPlan>,
+    mut rewriter: impl TreeNodeRewriter<Node = Arc<dyn ExecutionPlan>>,
+    rewrites_amount: usize,
+    batch_size: BatchSize,
+) {
+    let nodes_amount = nodes_amount(plan);
+    let mock_rewriter_exec = Arc::new(MockRewriterExec {
+        input: Arc::clone(plan),
+    });
+
+    group.bench_function(
+        format!(
+            "tree_node_rewriter_{batch_label}_{nodes_amount}_nodes_{rewrites_amount}_iteration(s)"
+        ),
+        |b| {
+            b.iter_batched(
+                || Arc::clone(&mock_rewriter_exec),
+                |plan| {
+                    for _ in 0..rewrites_amount {
+                        plan.execute(&mut rewriter).unwrap();
+                    }
+                },
+                batch_size,
+            )
+        },
+    );
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let depths = [5, 30];
+    let rules_count = [1, 2];
+    let batch_size = BatchSize::SmallInput;
+    let mut group = c.benchmark_group("plan_transformation");
+
+    for depth in depths {
+        let plan = create_deep_tree(depth);
+
+        for count in rules_count {
+            let reset_all_rules = (0..count)
+                .map(|_| Box::new(ResetAllRule {}) as Box<_>)
+                .collect::<Vec<_>>();
+
+            let reset_one_rules = (0..count)
+                .map(|_| {
+                    Box::new(ResetByNameRule {
+                        node_name: "EmptyExec".to_string(),
+                    }) as Box<_>
+                })
+                .collect::<Vec<_>>();
+
+            benchmark_with_transformer_exec(
+                &mut group,
+                "reset_all",
+                &plan,
+                &reset_all_rules,
+                batch_size,
+            );
+
+            benchmark_with_tree_node_rewriter(
+                &mut group,
+                "reset_all",
+                &plan,
+                ResetAllRewriter,
+                count,
+                batch_size,
+            );
+
+            benchmark_with_transformer_exec(
+                &mut group,
+                "reset_one",
+                &plan,
+                &reset_one_rules,
+                batch_size,
+            );
+
+            benchmark_with_tree_node_rewriter(
+                &mut group,
+                "reset_one",
+                &plan,
+                ResetByNameRewriter {
+                    node_name: "EmptyExec".to_string(),
+                },
+                count,
+                batch_size,
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/datafusion/physical-plan/src/lib.rs
+++ b/datafusion/physical-plan/src/lib.rs
@@ -81,6 +81,7 @@ pub mod limit;
 pub mod memory;
 pub mod metrics;
 pub mod placeholder_row;
+pub mod plan_transformer;
 pub mod projection;
 pub mod recursive_query;
 pub mod repartition;

--- a/datafusion/physical-plan/src/plan_transformer/mod.rs
+++ b/datafusion/physical-plan/src/plan_transformer/mod.rs
@@ -1,0 +1,629 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! This module provides a mechanism for two-pass [`ExecutionPlan`] tree transformations.
+//!
+//! In the first pass, the tree is visited (top-down) to identify nodes that require transformation
+//! based on certain criteria.
+//!
+//! In the second pass, the stored plans are applied to the tree (top-down) using a
+//! [`TreeNodeRewriter`].
+//!
+//! This approach is beneficial because it allows making multiple transformations during a single
+//! pass and caches node indices, ensuring that only nodes matching the criteria are transformed,
+//! which can improve performance.
+
+mod resolve_placeholders;
+
+pub use resolve_placeholders::ResolvePlaceholdersRule;
+
+use std::any::Any;
+use std::fmt::{self, Debug};
+use std::sync::Arc;
+
+use datafusion_common::{
+    Result,
+    tree_node::{
+        Transformed, TreeNode, TreeNodeRecursion, TreeNodeRewriter, TreeNodeVisitor,
+    },
+};
+use datafusion_execution::{SendableRecordBatchStream, TaskContext};
+use itertools::Itertools;
+
+use crate::metrics::{ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
+use crate::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, Statistics};
+
+/// A rule for transforming an [`ExecutionPlan`] node.
+///
+/// This trait is used in the two-pass tree transformation process. Both passes use a top-down
+/// traversal. In the first pass, the [`ExecutionTransformationRule::matches`] method is used to
+/// identify nodes that require transformation. In the second pass, the
+/// [`ExecutionTransformationRule::rewrite`] method is used to apply the transformation.
+pub trait ExecutionTransformationRule: Send + Sync + Debug {
+    /// Returns the rule name.
+    fn name(&self) -> &str;
+
+    /// Returns the rule as [`Any`] so that it can be downcast to a specific implementation.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Clones this rule.
+    fn clone_box(&self) -> Box<dyn ExecutionTransformationRule>;
+
+    /// Checks if the given [`ExecutionPlan`] node matches the criteria for this rule.
+    fn matches(&mut self, _node: &Arc<dyn ExecutionPlan>) -> Result<bool> {
+        Ok(false)
+    }
+
+    /// Transforms the given [`ExecutionPlan`] node.
+    fn rewrite(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        _ctx: &TaskContext,
+    ) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
+        Ok(Transformed::no(node))
+    }
+}
+
+/// Stores the transformation operations to be applied to an [`ExecutionPlan`] node at a specific
+/// index.
+#[derive(Debug, Clone)]
+struct TransformationPlan {
+    /// The index of the node in the tree traversal.
+    pub node_index: usize,
+    /// The list of transformation rule indices to apply.
+    pub rule_indices: Vec<usize>,
+}
+
+/// Helper for building transformation plans for an [`ExecutionPlan`] tree during a single pass.
+struct TransformationPlanner {
+    cursor: usize,
+    rules: Vec<Box<dyn ExecutionTransformationRule>>,
+    plans: Vec<TransformationPlan>,
+}
+
+impl TransformationPlanner {
+    fn new(rules: Vec<Box<dyn ExecutionTransformationRule>>) -> Self {
+        Self {
+            cursor: 0,
+            rules,
+            plans: Vec::new(),
+        }
+    }
+}
+
+impl<'n> TreeNodeVisitor<'n> for TransformationPlanner {
+    type Node = Arc<dyn ExecutionPlan>;
+
+    fn f_down(&mut self, node: &'n Self::Node) -> Result<TreeNodeRecursion> {
+        if node.as_any().is::<TransformPlanExec>() {
+            return Ok(TreeNodeRecursion::Jump);
+        }
+
+        let index = self.cursor;
+        self.cursor += 1;
+
+        let mut rule_indices = Vec::new();
+        for (rule_index, rule) in self.rules.iter_mut().enumerate() {
+            if rule.matches(node)? {
+                rule_indices.push(rule_index);
+            }
+        }
+
+        if !rule_indices.is_empty() {
+            self.plans.push(TransformationPlan {
+                node_index: index,
+                rule_indices,
+            });
+        }
+
+        Ok(TreeNodeRecursion::Continue)
+    }
+}
+
+/// Helper for applying transformation plans to an [`ExecutionPlan`] tree during a single pass.
+///
+/// This applier uses a [`TaskContext`] to provide necessary information for the transformation
+/// rules.
+struct TransformationApplier<'rules, 'plans, 'ctx> {
+    cursor: usize,
+    rules: &'rules [Box<dyn ExecutionTransformationRule>],
+    plans: &'plans [TransformationPlan],
+    ctx: &'ctx TaskContext,
+}
+
+impl<'rules, 'plans, 'ctx> TransformationApplier<'rules, 'plans, 'ctx> {
+    fn new(
+        rules: &'rules [Box<dyn ExecutionTransformationRule>],
+        plans: &'plans [TransformationPlan],
+        ctx: &'ctx TaskContext,
+    ) -> Self {
+        Self {
+            cursor: 0,
+            rules,
+            plans,
+            ctx,
+        }
+    }
+}
+
+impl<'rules, 'plans, 'ctx> TreeNodeRewriter
+    for TransformationApplier<'rules, 'plans, 'ctx>
+{
+    type Node = Arc<dyn ExecutionPlan>;
+
+    fn f_down(&mut self, mut node: Self::Node) -> Result<Transformed<Self::Node>> {
+        let Some(plan) = self.plans.first() else {
+            return Ok(Transformed::new(node, false, TreeNodeRecursion::Stop));
+        };
+
+        if node.as_any().is::<TransformPlanExec>() {
+            return Ok(Transformed::new(node, false, TreeNodeRecursion::Jump));
+        }
+
+        let index = self.cursor;
+        self.cursor += 1;
+
+        if index != plan.node_index {
+            return Ok(Transformed::no(node));
+        }
+
+        self.plans = &self.plans[1..];
+
+        let mut transformed = false;
+        for rule_index in plan.rule_indices.iter() {
+            let rule = &self.rules[*rule_index];
+            let transform = rule.rewrite(node, self.ctx)?;
+            node = transform.data;
+            transformed |= transform.transformed;
+        }
+
+        Ok(Transformed::new(
+            node,
+            transformed,
+            TreeNodeRecursion::Continue,
+        ))
+    }
+}
+
+/// An [`ExecutionPlan`] that applies transformation rules during execution.
+#[derive(Debug)]
+pub struct TransformPlanExec {
+    /// The input execution plan.
+    input: Arc<dyn ExecutionPlan>,
+    /// The transformation rules to apply.
+    rules: Vec<Box<dyn ExecutionTransformationRule>>,
+    /// The pre-calculated transformation plans.
+    plans: Vec<TransformationPlan>,
+    /// Execution metrics.
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl TransformPlanExec {
+    /// Create a new [TransformPlanExec].
+    ///
+    /// This method returns an error if any of the transformation rules return an error during the
+    /// initial traversal of the input plan.
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        rules: Vec<Box<dyn ExecutionTransformationRule>>,
+    ) -> Result<Self> {
+        let mut planner = TransformationPlanner::new(rules);
+        input.visit(&mut planner)?;
+
+        Ok(Self {
+            input,
+            rules: planner.rules,
+            plans: planner.plans,
+            metrics: ExecutionPlanMetricsSet::new(),
+        })
+    }
+
+    /// Returns the number of nodes that match at least one transformation rule.
+    pub fn plans_to_transform(&self) -> usize {
+        self.plans.len()
+    }
+
+    pub fn transform(
+        &self,
+        context: &Arc<TaskContext>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let mut applier = TransformationApplier::new(&self.rules, &self.plans, context);
+        let input = Arc::clone(&self.input);
+        input.rewrite(&mut applier).map(|t| t.data)
+    }
+
+    /// Returns the input plan.
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    /// Returns the transformation rules.
+    pub fn rules(&self) -> &[Box<dyn ExecutionTransformationRule>] {
+        &self.rules
+    }
+
+    /// Checks if the transformation rules contains a rule of a specific type.
+    pub fn has_rule<T: ExecutionTransformationRule + 'static>(&self) -> bool {
+        self.rules.iter().any(|r| r.as_any().is::<T>())
+    }
+
+    /// Adds a new transformation rule and recalculates transformation plans.
+    pub fn add_rule(
+        &self,
+        new_rule: Box<dyn ExecutionTransformationRule>,
+    ) -> Result<Self> {
+        self.add_rules(vec![new_rule])
+    }
+
+    /// Adds new transformation rules and recalculates transformation plans.
+    pub fn add_rules(
+        &self,
+        new_rules: Vec<Box<dyn ExecutionTransformationRule>>,
+    ) -> Result<Self> {
+        let mut planner = TransformationPlanner::new(new_rules);
+        self.input.visit(&mut planner)?;
+        let new_rules = planner.rules;
+        let new_plans = planner.plans;
+
+        let mut current_rules = self
+            .rules
+            .iter()
+            .map(|rule| rule.clone_box())
+            .collect::<Vec<_>>();
+
+        let offset = current_rules.len();
+        current_rules.extend(new_rules);
+
+        let mut merged_plans = Vec::with_capacity(self.plans.len() + new_plans.len());
+        let mut old_plans_iter = self.plans.iter().peekable();
+        let mut new_plans_iter = new_plans.into_iter().peekable();
+
+        while old_plans_iter.peek().is_some() || new_plans_iter.peek().is_some() {
+            match (old_plans_iter.peek(), new_plans_iter.peek()) {
+                (Some(&old), Some(new)) if old.node_index == new.node_index => {
+                    let mut merged_plan = old.clone();
+                    for &rule_index in &new.rule_indices {
+                        merged_plan.rule_indices.push(offset + rule_index);
+                    }
+                    merged_plans.push(merged_plan);
+                    old_plans_iter.next();
+                    new_plans_iter.next();
+                }
+                (Some(&old), Some(new)) if old.node_index < new.node_index => {
+                    merged_plans.push(old.clone());
+                    old_plans_iter.next();
+                }
+                (Some(_), Some(_)) => {
+                    // old_node_index > new.node_index
+                    let mut new_plan = new_plans_iter.next().unwrap();
+                    for rule_index in new_plan.rule_indices.iter_mut() {
+                        *rule_index += offset;
+                    }
+                    merged_plans.push(new_plan);
+                }
+                (Some(&old), None) => {
+                    merged_plans.push(old.clone());
+                    old_plans_iter.next();
+                }
+                (None, Some(_)) => {
+                    let mut new_plan = new_plans_iter.next().unwrap();
+                    for rule_index in new_plan.rule_indices.iter_mut() {
+                        *rule_index += offset;
+                    }
+                    merged_plans.push(new_plan);
+                }
+                (None, None) => unreachable!(),
+            }
+        }
+
+        Ok(Self {
+            input: Arc::clone(&self.input),
+            rules: current_rules,
+            plans: merged_plans,
+            metrics: ExecutionPlanMetricsSet::new(),
+        })
+    }
+}
+
+impl DisplayAs for TransformPlanExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                let mut rule_to_nodes_count = vec![0; self.rules.len()];
+                for plan in self.plans.iter() {
+                    for rule_index in plan.rule_indices.iter() {
+                        rule_to_nodes_count[*rule_index] += 1;
+                    }
+                }
+
+                let rules = rule_to_nodes_count
+                    .into_iter()
+                    .enumerate()
+                    .map(|(rule_index, nodes_count)| {
+                        let rule_name = self.rules[rule_index].name();
+                        format!("{rule_name}: plans_to_modify={nodes_count}")
+                    })
+                    .join(", ");
+
+                write!(f, "TransformPlanExec: rules=[{rules}]")
+            }
+            DisplayFormatType::TreeRender => Ok(()),
+        }
+    }
+}
+
+impl ExecutionPlan for TransformPlanExec {
+    fn static_name() -> &'static str
+    where
+        Self: Sized,
+    {
+        "TransformPlanExec"
+    }
+
+    fn name(&self) -> &str {
+        Self::static_name()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        self.input.properties()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let rules = self.rules.iter().map(|r| r.clone_box()).collect();
+        Ok(Arc::new(TransformPlanExec::try_new(
+            Arc::clone(&children[0]),
+            rules,
+        )?))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let metric = MetricBuilder::new(&self.metrics).elapsed_compute(partition);
+        let _timer = metric.timer();
+
+        let transformed = self.transform(&context)?;
+        transformed.execute(partition, context)
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn statistics(&self) -> Result<Statistics> {
+        self.partition_statistics(None)
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        self.input.partition_statistics(partition)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coalesce_partitions::CoalescePartitionsExec;
+    use crate::empty::EmptyExec;
+    use crate::limit::GlobalLimitExec;
+    use crate::placeholder_row::PlaceholderRowExec;
+    use crate::plan_transformer::resolve_placeholders::ResolvePlaceholdersRule;
+    use crate::projection::ProjectionExec;
+    use crate::{get_plan_string, test};
+    use arrow_schema::{DataType, Schema};
+    use datafusion_common::{ParamValues, ScalarValue, tree_node::Transformed};
+    use datafusion_expr::Operator;
+    use datafusion_physical_expr::expressions::{binary, lit, placeholder};
+    use datafusion_physical_expr::projection::ProjectionExpr;
+    use insta::assert_snapshot;
+    use std::sync::Arc;
+
+    #[derive(Debug, Clone)]
+    struct MockRule {
+        name: String,
+        match_name: String,
+    }
+
+    impl ExecutionTransformationRule for MockRule {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn clone_box(&self) -> Box<dyn ExecutionTransformationRule> {
+            Box::new(self.clone())
+        }
+
+        fn matches(&mut self, node: &Arc<dyn ExecutionPlan>) -> Result<bool> {
+            Ok(node.name() == self.match_name || self.match_name == "all")
+        }
+
+        fn rewrite(
+            &self,
+            node: Arc<dyn ExecutionPlan>,
+            _ctx: &TaskContext,
+        ) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
+            Ok(Transformed::no(node))
+        }
+    }
+
+    #[test]
+    fn test_has_rule() -> Result<()> {
+        let schema = Arc::new(Schema::empty());
+        let input = Arc::new(EmptyExec::new(schema));
+
+        let resolve_rule = Box::new(ResolvePlaceholdersRule::new());
+        let exec = TransformPlanExec::try_new(input, vec![resolve_rule])?;
+        assert!(exec.has_rule::<ResolvePlaceholdersRule>());
+        assert!(!exec.has_rule::<MockRule>());
+
+        let exec = exec.add_rule(Box::new(MockRule {
+            name: "mock".to_string(),
+            match_name: "any".to_string(),
+        }))?;
+
+        assert!(exec.has_rule::<ResolvePlaceholdersRule>());
+        assert!(exec.has_rule::<MockRule>());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_add_rules_merge() -> Result<()> {
+        let schema = Arc::new(Schema::empty());
+        let empty = Arc::new(EmptyExec::new(schema));
+        let coalesce = Arc::new(CoalescePartitionsExec::new(empty));
+        let input = Arc::new(GlobalLimitExec::new(coalesce, 0, None)) as Arc<_>;
+
+        // Node 0: GlobalLimitExec
+        // Node 1: CoalescePartitionsExec
+        // Node 2: EmptyExec
+
+        let rule_a = Box::new(MockRule {
+            name: "ruleA".to_string(),
+            match_name: "CoalescePartitionsExec".to_string(),
+        });
+        let exec = TransformPlanExec::try_new(Arc::clone(&input), vec![rule_a.clone()])?;
+
+        assert_eq!(exec.rules.len(), 1);
+        assert_eq!(exec.plans.len(), 1);
+        assert_eq!(exec.plans[0].node_index, 1);
+        assert_eq!(exec.plans[0].rule_indices, vec![0]);
+
+        let rule_b = Box::new(MockRule {
+            name: "ruleB".to_string(),
+            match_name: "GlobalLimitExec".to_string(),
+        });
+        let exec = exec.add_rules(vec![rule_b.clone()])?;
+
+        assert_eq!(exec.rules.len(), 2);
+        assert_eq!(exec.plans.len(), 2);
+        assert_eq!(exec.plans[0].node_index, 0);
+        assert_eq!(exec.plans[0].rule_indices, vec![1]);
+        assert_eq!(exec.plans[1].node_index, 1);
+        assert_eq!(exec.plans[1].rule_indices, vec![0]);
+
+        let rule_c = Box::new(MockRule {
+            name: "ruleC".to_string(),
+            match_name: "EmptyExec".to_string(),
+        });
+        let exec = exec.add_rules(vec![rule_c.clone()])?;
+
+        assert_eq!(exec.rules.len(), 3);
+        assert_eq!(exec.plans.len(), 3);
+        assert_eq!(exec.plans[0].node_index, 0);
+        assert_eq!(exec.plans[0].rule_indices, vec![1]);
+        assert_eq!(exec.plans[1].node_index, 1);
+        assert_eq!(exec.plans[1].rule_indices, vec![0]);
+        assert_eq!(exec.plans[2].node_index, 2);
+        assert_eq!(exec.plans[2].rule_indices, vec![2]);
+
+        let rule_d = Box::new(MockRule {
+            name: "ruleD".to_string(),
+            match_name: "all".to_string(),
+        });
+
+        let exec = exec.add_rules(vec![rule_d.clone()])?;
+        let check_full_plan = |exec: TransformPlanExec| {
+            assert_eq!(exec.rules.len(), 4);
+            assert_eq!(exec.plans.len(), 3);
+            assert_eq!(exec.plans[0].node_index, 0);
+            assert_eq!(exec.plans[0].rule_indices, vec![1, 3]);
+            assert_eq!(exec.plans[1].node_index, 1);
+            assert_eq!(exec.plans[1].rule_indices, vec![0, 3]);
+            assert_eq!(exec.plans[2].node_index, 2);
+            assert_eq!(exec.plans[2].rule_indices, vec![2, 3]);
+        };
+
+        check_full_plan(exec);
+
+        let exec = TransformPlanExec::try_new(
+            Arc::clone(&input),
+            vec![
+                rule_a.clone(),
+                rule_b.clone(),
+                rule_c.clone(),
+                rule_d.clone(),
+            ],
+        )?;
+
+        check_full_plan(exec);
+
+        let exec = TransformPlanExec::try_new(Arc::clone(&input), vec![rule_a])?
+            .add_rules(vec![rule_b, rule_c, rule_d])?;
+
+        check_full_plan(exec);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_consts_evaluation() -> Result<()> {
+        let schema = test::aggr_test_schema();
+        let expr = binary(
+            lit(10),
+            Operator::Plus,
+            binary(
+                lit(5),
+                Operator::Multiply,
+                placeholder("$1", DataType::Int32),
+                &schema,
+            )?,
+            &schema,
+        )?;
+
+        let projection_expr = ProjectionExpr {
+            expr,
+            alias: "sum".to_string(),
+        };
+
+        let row = Arc::new(PlaceholderRowExec::new(schema));
+        let projection = ProjectionExec::try_new(vec![projection_expr], row)?;
+        let transformer = TransformPlanExec::try_new(
+            Arc::new(projection),
+            vec![Box::new(ResolvePlaceholdersRule::new())],
+        )?;
+
+        let param_values = ParamValues::List(vec![ScalarValue::Int32(Some(20)).into()]);
+        let task_ctx = Arc::new(TaskContext::default().with_param_values(param_values));
+
+        let plan = transformer.transform(&task_ctx)?;
+        let plan_string = get_plan_string(&plan).join("\n");
+
+        assert_snapshot!(plan_string, @r"
+        ProjectionExec: expr=[110 as sum]
+          PlaceholderRowExec
+        ");
+
+        Ok(())
+    }
+}

--- a/datafusion/physical-plan/src/plan_transformer/resolve_placeholders.rs
+++ b/datafusion/physical-plan/src/plan_transformer/resolve_placeholders.rs
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Rule to resolve placeholders in the physical plan with actual values.
+
+use std::sync::Arc;
+
+use datafusion_common::{
+    ParamValues, Result, exec_err,
+    tree_node::{Transformed, TreeNode},
+};
+use datafusion_execution::TaskContext;
+use datafusion_physical_expr::{
+    PhysicalExpr,
+    expressions::{Literal, PlaceholderExpr, has_placeholders},
+    simplifier::const_evaluator::simplify_const_expr,
+};
+
+use crate::{ExecutionPlan, plan_transformer::ExecutionTransformationRule};
+
+/// A transformation rule that replaces [`PlaceholderExpr`] with actual values.
+///
+/// This rule is applied to the physical plan when actual parameter values are provided in the
+/// [`TaskContext`]. It traverses the plan and replaces any placeholders found in physical
+/// expressions with their corresponding literal values.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvePlaceholdersRule {}
+
+impl ResolvePlaceholdersRule {
+    /// Create a new [`ResolvePlaceholdersRule`].
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl ExecutionTransformationRule for ResolvePlaceholdersRule {
+    fn name(&self) -> &str {
+        "ResolvePlaceholders"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn clone_box(&self) -> Box<dyn ExecutionTransformationRule> {
+        Box::new(Self {})
+    }
+
+    fn matches(&mut self, node: &Arc<dyn ExecutionPlan>) -> Result<bool> {
+        let Some(exprs) = node.physical_expressions() else {
+            return Ok(false);
+        };
+
+        for expr in exprs {
+            if has_placeholders(&expr) {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn rewrite(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        ctx: &TaskContext,
+    ) -> Result<Transformed<Arc<dyn ExecutionPlan>>> {
+        let Some(param_values) = ctx.param_values() else {
+            return Ok(Transformed::no(node));
+        };
+
+        let Some(exprs) = node.physical_expressions() else {
+            return exec_err!("no physical expressions found");
+        };
+
+        let new_exprs = exprs
+            .map(|expr| resolve_expr_placeholders(expr, param_values))
+            .collect::<Result<Vec<_>>>()?;
+
+        match node.with_physical_expressions(new_exprs.into())? {
+            Some(transformed_plan) => Ok(Transformed::yes(transformed_plan)),
+            None => exec_err!("failed to rewrite execution plan"),
+        }
+    }
+}
+
+/// Resolves [`PlaceholderExpr`] in the physical expression using the provided [`ParamValues`].
+pub fn resolve_expr_placeholders(
+    expr: Arc<dyn PhysicalExpr>,
+    param_values: &ParamValues,
+) -> Result<Arc<dyn PhysicalExpr>> {
+    let expr = expr.transform_up(|node| {
+        let Some(placeholder) = node.as_any().downcast_ref::<PlaceholderExpr>() else {
+            return Ok(Transformed::no(node));
+        };
+
+        if let Some(ref field) = placeholder.field {
+            let scalar = param_values.get_placeholders_with_values(&placeholder.id)?;
+            let value = scalar.value.cast_to(field.data_type())?;
+            let literal = Literal::new_with_metadata(value, scalar.metadata);
+            Ok(Transformed::yes(Arc::new(literal)))
+        } else {
+            Ok(Transformed::no(node))
+        }
+    })?;
+
+    if expr.transformed {
+        simplify_const_expr(expr.data).map(|t| t.data)
+    } else {
+        Ok(expr.data)
+    }
+}

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -896,6 +896,8 @@ message PhysicalExprNode {
     UnknownColumn unknown_column = 20;
 
     PhysicalHashExprNode hash_expr = 21;
+
+    PhysicalPlaceholderNode placeholder_expr = 22;
   }
 }
 
@@ -1021,6 +1023,11 @@ message PhysicalHashExprNode {
   uint64 seed2 = 4;
   uint64 seed3 = 5;
   string description = 6;
+}
+
+message PhysicalPlaceholderNode {
+  string id = 1;
+  optional datafusion_common.Field field = 2;
 }
 
 message FilterExecNode {

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -751,6 +751,7 @@ message PhysicalPlanNode {
     MemoryScanExecNode memory_scan = 35;
     AsyncFuncExecNode async_func = 36;
     BufferExecNode buffer = 37;
+    TransformPlanExecNode transform_plan = 38;
   }
 }
 
@@ -1451,3 +1452,17 @@ message BufferExecNode {
   PhysicalPlanNode input = 1;
   uint64 capacity = 2;
 }
+
+message TransformPlanExecNode {
+  PhysicalPlanNode input = 1;
+  repeated TransformationRule rules = 2;
+}
+
+message TransformationRule {
+  oneof rule_type {
+    bytes extension = 1;
+    ResolvePlaceholdersRule resolve_placeholders = 2;
+  }
+}
+
+message ResolvePlaceholdersRule {}

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -16212,6 +16212,9 @@ impl serde::Serialize for PhysicalExprNode {
                 physical_expr_node::ExprType::HashExpr(v) => {
                     struct_ser.serialize_field("hashExpr", v)?;
                 }
+                physical_expr_node::ExprType::PlaceholderExpr(v) => {
+                    struct_ser.serialize_field("placeholderExpr", v)?;
+                }
             }
         }
         struct_ser.end()
@@ -16258,6 +16261,8 @@ impl<'de> serde::Deserialize<'de> for PhysicalExprNode {
             "unknownColumn",
             "hash_expr",
             "hashExpr",
+            "placeholder_expr",
+            "placeholderExpr",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -16282,6 +16287,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalExprNode {
             Extension,
             UnknownColumn,
             HashExpr,
+            PlaceholderExpr,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -16323,6 +16329,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalExprNode {
                             "extension" => Ok(GeneratedField::Extension),
                             "unknownColumn" | "unknown_column" => Ok(GeneratedField::UnknownColumn),
                             "hashExpr" | "hash_expr" => Ok(GeneratedField::HashExpr),
+                            "placeholderExpr" | "placeholder_expr" => Ok(GeneratedField::PlaceholderExpr),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -16485,6 +16492,13 @@ impl<'de> serde::Deserialize<'de> for PhysicalExprNode {
                                 return Err(serde::de::Error::duplicate_field("hashExpr"));
                             }
                             expr_type__ = map_.next_value::<::std::option::Option<_>>()?.map(physical_expr_node::ExprType::HashExpr)
+;
+                        }
+                        GeneratedField::PlaceholderExpr => {
+                            if expr_type__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("placeholderExpr"));
+                            }
+                            expr_type__ = map_.next_value::<::std::option::Option<_>>()?.map(physical_expr_node::ExprType::PlaceholderExpr)
 ;
                         }
                     }
@@ -17659,6 +17673,114 @@ impl<'de> serde::Deserialize<'de> for PhysicalNot {
             }
         }
         deserializer.deserialize_struct("datafusion.PhysicalNot", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for PhysicalPlaceholderNode {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if !self.id.is_empty() {
+            len += 1;
+        }
+        if self.field.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("datafusion.PhysicalPlaceholderNode", len)?;
+        if !self.id.is_empty() {
+            struct_ser.serialize_field("id", &self.id)?;
+        }
+        if let Some(v) = self.field.as_ref() {
+            struct_ser.serialize_field("field", v)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for PhysicalPlaceholderNode {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "id",
+            "field",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Id,
+            Field,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl serde::de::Visitor<'_> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "id" => Ok(GeneratedField::Id),
+                            "field" => Ok(GeneratedField::Field),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = PhysicalPlaceholderNode;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct datafusion.PhysicalPlaceholderNode")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<PhysicalPlaceholderNode, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut id__ = None;
+                let mut field__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Id => {
+                            if id__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("id"));
+                            }
+                            id__ = Some(map_.next_value()?);
+                        }
+                        GeneratedField::Field => {
+                            if field__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("field"));
+                            }
+                            field__ = map_.next_value()?;
+                        }
+                    }
+                }
+                Ok(PhysicalPlaceholderNode {
+                    id: id__.unwrap_or_default(),
+                    field: field__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("datafusion.PhysicalPlaceholderNode", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for PhysicalPlanNode {

--- a/datafusion/proto/src/generated/pbjson.rs
+++ b/datafusion/proto/src/generated/pbjson.rs
@@ -17905,6 +17905,9 @@ impl serde::Serialize for PhysicalPlanNode {
                 physical_plan_node::PhysicalPlanType::Buffer(v) => {
                     struct_ser.serialize_field("buffer", v)?;
                 }
+                physical_plan_node::PhysicalPlanType::TransformPlan(v) => {
+                    struct_ser.serialize_field("transformPlan", v)?;
+                }
             }
         }
         struct_ser.end()
@@ -17973,6 +17976,8 @@ impl<'de> serde::Deserialize<'de> for PhysicalPlanNode {
             "async_func",
             "asyncFunc",
             "buffer",
+            "transform_plan",
+            "transformPlan",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -18013,6 +18018,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalPlanNode {
             MemoryScan,
             AsyncFunc,
             Buffer,
+            TransformPlan,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -18070,6 +18076,7 @@ impl<'de> serde::Deserialize<'de> for PhysicalPlanNode {
                             "memoryScan" | "memory_scan" => Ok(GeneratedField::MemoryScan),
                             "asyncFunc" | "async_func" => Ok(GeneratedField::AsyncFunc),
                             "buffer" => Ok(GeneratedField::Buffer),
+                            "transformPlan" | "transform_plan" => Ok(GeneratedField::TransformPlan),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -18342,6 +18349,13 @@ impl<'de> serde::Deserialize<'de> for PhysicalPlanNode {
                                 return Err(serde::de::Error::duplicate_field("buffer"));
                             }
                             physical_plan_type__ = map_.next_value::<::std::option::Option<_>>()?.map(physical_plan_node::PhysicalPlanType::Buffer)
+;
+                        }
+                        GeneratedField::TransformPlan => {
+                            if physical_plan_type__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("transformPlan"));
+                            }
+                            physical_plan_type__ = map_.next_value::<::std::option::Option<_>>()?.map(physical_plan_node::PhysicalPlanType::TransformPlan)
 ;
                         }
                     }
@@ -20914,6 +20928,77 @@ impl<'de> serde::Deserialize<'de> for RepartitionNode {
         deserializer.deserialize_struct("datafusion.RepartitionNode", FIELDS, GeneratedVisitor)
     }
 }
+impl serde::Serialize for ResolvePlaceholdersRule {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let len = 0;
+        let struct_ser = serializer.serialize_struct("datafusion.ResolvePlaceholdersRule", len)?;
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for ResolvePlaceholdersRule {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl serde::de::Visitor<'_> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                            Err(serde::de::Error::unknown_field(value, FIELDS))
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = ResolvePlaceholdersRule;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct datafusion.ResolvePlaceholdersRule")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<ResolvePlaceholdersRule, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                while map_.next_key::<GeneratedField>()?.is_some() {
+                    let _ = map_.next_value::<serde::de::IgnoredAny>()?;
+                }
+                Ok(ResolvePlaceholdersRule {
+                })
+            }
+        }
+        deserializer.deserialize_struct("datafusion.ResolvePlaceholdersRule", FIELDS, GeneratedVisitor)
+    }
+}
 impl serde::Serialize for RollupNode {
     #[allow(deprecated)]
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
@@ -23040,6 +23125,225 @@ impl<'de> serde::Deserialize<'de> for TableReference {
             }
         }
         deserializer.deserialize_struct("datafusion.TableReference", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for TransformPlanExecNode {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.input.is_some() {
+            len += 1;
+        }
+        if !self.rules.is_empty() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("datafusion.TransformPlanExecNode", len)?;
+        if let Some(v) = self.input.as_ref() {
+            struct_ser.serialize_field("input", v)?;
+        }
+        if !self.rules.is_empty() {
+            struct_ser.serialize_field("rules", &self.rules)?;
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for TransformPlanExecNode {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "input",
+            "rules",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Input,
+            Rules,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl serde::de::Visitor<'_> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "input" => Ok(GeneratedField::Input),
+                            "rules" => Ok(GeneratedField::Rules),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TransformPlanExecNode;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct datafusion.TransformPlanExecNode")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TransformPlanExecNode, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut input__ = None;
+                let mut rules__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Input => {
+                            if input__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("input"));
+                            }
+                            input__ = map_.next_value()?;
+                        }
+                        GeneratedField::Rules => {
+                            if rules__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("rules"));
+                            }
+                            rules__ = Some(map_.next_value()?);
+                        }
+                    }
+                }
+                Ok(TransformPlanExecNode {
+                    input: input__,
+                    rules: rules__.unwrap_or_default(),
+                })
+            }
+        }
+        deserializer.deserialize_struct("datafusion.TransformPlanExecNode", FIELDS, GeneratedVisitor)
+    }
+}
+impl serde::Serialize for TransformationRule {
+    #[allow(deprecated)]
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut len = 0;
+        if self.rule_type.is_some() {
+            len += 1;
+        }
+        let mut struct_ser = serializer.serialize_struct("datafusion.TransformationRule", len)?;
+        if let Some(v) = self.rule_type.as_ref() {
+            match v {
+                transformation_rule::RuleType::Extension(v) => {
+                    #[allow(clippy::needless_borrow)]
+                    #[allow(clippy::needless_borrows_for_generic_args)]
+                    struct_ser.serialize_field("extension", pbjson::private::base64::encode(&v).as_str())?;
+                }
+                transformation_rule::RuleType::ResolvePlaceholders(v) => {
+                    struct_ser.serialize_field("resolvePlaceholders", v)?;
+                }
+            }
+        }
+        struct_ser.end()
+    }
+}
+impl<'de> serde::Deserialize<'de> for TransformationRule {
+    #[allow(deprecated)]
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: &[&str] = &[
+            "extension",
+            "resolve_placeholders",
+            "resolvePlaceholders",
+        ];
+
+        #[allow(clippy::enum_variant_names)]
+        enum GeneratedField {
+            Extension,
+            ResolvePlaceholders,
+        }
+        impl<'de> serde::Deserialize<'de> for GeneratedField {
+            fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                struct GeneratedVisitor;
+
+                impl serde::de::Visitor<'_> for GeneratedVisitor {
+                    type Value = GeneratedField;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        write!(formatter, "expected one of: {:?}", &FIELDS)
+                    }
+
+                    #[allow(unused_variables)]
+                    fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
+                    where
+                        E: serde::de::Error,
+                    {
+                        match value {
+                            "extension" => Ok(GeneratedField::Extension),
+                            "resolvePlaceholders" | "resolve_placeholders" => Ok(GeneratedField::ResolvePlaceholders),
+                            _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
+                        }
+                    }
+                }
+                deserializer.deserialize_identifier(GeneratedVisitor)
+            }
+        }
+        struct GeneratedVisitor;
+        impl<'de> serde::de::Visitor<'de> for GeneratedVisitor {
+            type Value = TransformationRule;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("struct datafusion.TransformationRule")
+            }
+
+            fn visit_map<V>(self, mut map_: V) -> std::result::Result<TransformationRule, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+            {
+                let mut rule_type__ = None;
+                while let Some(k) = map_.next_key()? {
+                    match k {
+                        GeneratedField::Extension => {
+                            if rule_type__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("extension"));
+                            }
+                            rule_type__ = map_.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| transformation_rule::RuleType::Extension(x.0));
+                        }
+                        GeneratedField::ResolvePlaceholders => {
+                            if rule_type__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("resolvePlaceholders"));
+                            }
+                            rule_type__ = map_.next_value::<::std::option::Option<_>>()?.map(transformation_rule::RuleType::ResolvePlaceholders)
+;
+                        }
+                    }
+                }
+                Ok(TransformationRule {
+                    rule_type: rule_type__,
+                })
+            }
+        }
+        deserializer.deserialize_struct("datafusion.TransformationRule", FIELDS, GeneratedVisitor)
     }
 }
 impl serde::Serialize for TryCastNode {

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1292,7 +1292,7 @@ pub struct PhysicalExprNode {
     pub expr_id: ::core::option::Option<u64>,
     #[prost(
         oneof = "physical_expr_node::ExprType",
-        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 18, 19, 20, 21"
+        tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 18, 19, 20, 21, 22"
     )]
     pub expr_type: ::core::option::Option<physical_expr_node::ExprType>,
 }
@@ -1345,6 +1345,8 @@ pub mod physical_expr_node {
         UnknownColumn(super::UnknownColumn),
         #[prost(message, tag = "21")]
         HashExpr(super::PhysicalHashExprNode),
+        #[prost(message, tag = "22")]
+        PlaceholderExpr(super::PhysicalPlaceholderNode),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1548,6 +1550,13 @@ pub struct PhysicalHashExprNode {
     pub seed3: u64,
     #[prost(string, tag = "6")]
     pub description: ::prost::alloc::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PhysicalPlaceholderNode {
+    #[prost(string, tag = "1")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub field: ::core::option::Option<super::datafusion_common::Field>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FilterExecNode {

--- a/datafusion/proto/src/generated/prost.rs
+++ b/datafusion/proto/src/generated/prost.rs
@@ -1079,7 +1079,7 @@ pub mod table_reference {
 pub struct PhysicalPlanNode {
     #[prost(
         oneof = "physical_plan_node::PhysicalPlanType",
-        tags = "1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37"
+        tags = "1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38"
     )]
     pub physical_plan_type: ::core::option::Option<physical_plan_node::PhysicalPlanType>,
 }
@@ -1161,6 +1161,8 @@ pub mod physical_plan_node {
         AsyncFunc(::prost::alloc::boxed::Box<super::AsyncFuncExecNode>),
         #[prost(message, tag = "37")]
         Buffer(::prost::alloc::boxed::Box<super::BufferExecNode>),
+        #[prost(message, tag = "38")]
+        TransformPlan(::prost::alloc::boxed::Box<super::TransformPlanExecNode>),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2173,6 +2175,30 @@ pub struct BufferExecNode {
     #[prost(uint64, tag = "2")]
     pub capacity: u64,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransformPlanExecNode {
+    #[prost(message, optional, boxed, tag = "1")]
+    pub input: ::core::option::Option<::prost::alloc::boxed::Box<PhysicalPlanNode>>,
+    #[prost(message, repeated, tag = "2")]
+    pub rules: ::prost::alloc::vec::Vec<TransformationRule>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct TransformationRule {
+    #[prost(oneof = "transformation_rule::RuleType", tags = "1, 2")]
+    pub rule_type: ::core::option::Option<transformation_rule::RuleType>,
+}
+/// Nested message and enum types in `TransformationRule`.
+pub mod transformation_rule {
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum RuleType {
+        #[prost(bytes, tag = "1")]
+        Extension(::prost::alloc::vec::Vec<u8>),
+        #[prost(message, tag = "2")]
+        ResolvePlaceholders(super::ResolvePlaceholdersRule),
+    }
+}
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResolvePlaceholdersRule {}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum WindowFrameUnits {

--- a/datafusion/proto/src/physical_plan/from_proto.rs
+++ b/datafusion/proto/src/physical_plan/from_proto.rs
@@ -42,7 +42,7 @@ use datafusion_physical_expr::projection::{ProjectionExpr, ProjectionExprs};
 use datafusion_physical_expr::{LexOrdering, PhysicalSortExpr, ScalarFunctionExpr};
 use datafusion_physical_plan::expressions::{
     BinaryExpr, CaseExpr, CastExpr, Column, IsNotNullExpr, IsNullExpr, LikeExpr, Literal,
-    NegativeExpr, NotExpr, TryCastExpr, UnKnownColumn, in_list,
+    NegativeExpr, NotExpr, PlaceholderExpr, TryCastExpr, UnKnownColumn, in_list,
 };
 use datafusion_physical_plan::joins::{HashExpr, SeededRandomState};
 use datafusion_physical_plan::windows::{create_window_expr, schema_add_window_field};
@@ -495,6 +495,15 @@ pub fn parse_physical_expr_with_converter(
                 hash_expr.description.clone(),
             ))
         }
+        ExprType::PlaceholderExpr(placeholder_expr) => match placeholder_expr.field {
+            Some(ref field) => Arc::new(PlaceholderExpr::new_with_field(
+                placeholder_expr.id.clone(),
+                Arc::new(field.try_into()?),
+            )),
+            None => Arc::new(PlaceholderExpr::new_without_data_type(
+                placeholder_expr.id.clone(),
+            )),
+        },
         ExprType::Extension(extension) => {
             let inputs: Vec<Arc<dyn PhysicalExpr>> = extension
                 .inputs

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -75,6 +75,9 @@ use datafusion_physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use datafusion_physical_plan::memory::LazyMemoryExec;
 use datafusion_physical_plan::metrics::MetricType;
 use datafusion_physical_plan::placeholder_row::PlaceholderRowExec;
+use datafusion_physical_plan::plan_transformer::{
+    ExecutionTransformationRule, ResolvePlaceholdersRule, TransformPlanExec,
+};
 use datafusion_physical_plan::projection::{ProjectionExec, ProjectionExpr};
 use datafusion_physical_plan::repartition::RepartitionExec;
 use datafusion_physical_plan::sorts::sort::SortExec;
@@ -102,6 +105,7 @@ use crate::physical_plan::to_proto::{
 use crate::protobuf::physical_aggregate_expr_node::AggregateFunction;
 use crate::protobuf::physical_expr_node::ExprType;
 use crate::protobuf::physical_plan_node::PhysicalPlanType;
+use crate::protobuf::transformation_rule::RuleType;
 use crate::protobuf::{
     self, ListUnnest as ProtoListUnnest, SortExprNode, SortMergeJoinExecNode,
     proto_error, window_agg_exec_node,
@@ -312,6 +316,13 @@ impl protobuf::PhysicalPlanNode {
             PhysicalPlanType::Buffer(buffer) => {
                 self.try_into_buffer_physical_plan(buffer, ctx, codec, proto_converter)
             }
+            PhysicalPlanType::TransformPlan(transform_plan) => self
+                .try_into_transform_plan_exec(
+                    transform_plan,
+                    ctx,
+                    codec,
+                    proto_converter,
+                ),
         }
     }
 
@@ -554,6 +565,14 @@ impl protobuf::PhysicalPlanNode {
 
         if let Some(exec) = plan.downcast_ref::<BufferExec>() {
             return protobuf::PhysicalPlanNode::try_from_buffer_exec(
+                exec,
+                codec,
+                proto_converter,
+            );
+        }
+
+        if let Some(exec) = plan.downcast_ref::<TransformPlanExec>() {
+            return protobuf::PhysicalPlanNode::try_from_transform_plan_exec(
                 exec,
                 codec,
                 proto_converter,
@@ -2198,6 +2217,37 @@ impl protobuf::PhysicalPlanNode {
         Ok(Arc::new(BufferExec::new(input, buffer.capacity as usize)))
     }
 
+    fn try_into_transform_plan_exec(
+        &self,
+        transform_plan: &protobuf::TransformPlanExecNode,
+        ctx: &TaskContext,
+        codec: &dyn PhysicalExtensionCodec,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let input: Arc<dyn ExecutionPlan> =
+            into_physical_plan(&transform_plan.input, ctx, codec, proto_converter)?;
+
+        let mut rules: Vec<Box<dyn ExecutionTransformationRule>> =
+            Vec::with_capacity(transform_plan.rules.len());
+
+        for rule in transform_plan.rules.iter() {
+            match &rule.rule_type {
+                Some(RuleType::ResolvePlaceholders(_)) => {
+                    rules.push(Box::new(ResolvePlaceholdersRule::new()))
+                }
+                Some(RuleType::Extension(ext)) => {
+                    rules.push(codec.try_decode_transformation_rule(ext)?)
+                }
+                None => {
+                    return internal_err!("Missing rule_type in TransformationRule");
+                }
+            }
+        }
+
+        let transformer = TransformPlanExec::try_new(input, rules)?;
+        Ok(Arc::new(transformer))
+    }
+
     fn try_from_explain_exec(
         exec: &ExplainExec,
         _codec: &dyn PhysicalExtensionCodec,
@@ -3567,6 +3617,42 @@ impl protobuf::PhysicalPlanNode {
             ))),
         })
     }
+
+    fn try_from_transform_plan_exec(
+        exec: &TransformPlanExec,
+        extension_codec: &dyn PhysicalExtensionCodec,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
+    ) -> Result<Self> {
+        let input = protobuf::PhysicalPlanNode::try_from_physical_plan_with_converter(
+            Arc::clone(exec.input()),
+            extension_codec,
+            proto_converter,
+        )?;
+
+        let mut rules = Vec::with_capacity(exec.rules().len());
+        for rule in exec.rules() {
+            let rule_type = if rule.as_any().is::<ResolvePlaceholdersRule>() {
+                Some(RuleType::ResolvePlaceholders(
+                    protobuf::ResolvePlaceholdersRule {},
+                ))
+            } else {
+                let mut buf = vec![];
+                extension_codec
+                    .try_encode_transformation_rule(rule.as_ref(), &mut buf)?;
+                Some(RuleType::Extension(buf))
+            };
+            rules.push(protobuf::TransformationRule { rule_type });
+        }
+
+        Ok(protobuf::PhysicalPlanNode {
+            physical_plan_type: Some(PhysicalPlanType::TransformPlan(Box::new(
+                protobuf::TransformPlanExecNode {
+                    input: Some(Box::new(input)),
+                    rules,
+                },
+            ))),
+        })
+    }
 }
 
 pub trait AsExecutionPlan: Debug + Send + Sync + Clone {
@@ -3636,6 +3722,21 @@ pub trait PhysicalExtensionCodec: Debug + Send + Sync {
 
     fn try_encode_udaf(&self, _node: &AggregateUDF, _buf: &mut Vec<u8>) -> Result<()> {
         Ok(())
+    }
+
+    fn try_decode_transformation_rule(
+        &self,
+        _buf: &[u8],
+    ) -> Result<Box<dyn ExecutionTransformationRule>> {
+        not_impl_err!("PhysicalExtensionCodec is not provided")
+    }
+
+    fn try_encode_transformation_rule(
+        &self,
+        _node: &dyn ExecutionTransformationRule,
+        _buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        not_impl_err!("PhysicalExtensionCodec is not provided")
     }
 
     fn try_decode_udwf(&self, name: &str, _buf: &[u8]) -> Result<Arc<WindowUDF>> {
@@ -4070,6 +4171,25 @@ impl PhysicalExtensionCodec for ComposedPhysicalExtensionCodec {
 
     fn try_encode_udaf(&self, node: &AggregateUDF, buf: &mut Vec<u8>) -> Result<()> {
         self.encode_protobuf(buf, |codec, data| codec.try_encode_udaf(node, data))
+    }
+
+    fn try_decode_transformation_rule(
+        &self,
+        buf: &[u8],
+    ) -> Result<Box<dyn ExecutionTransformationRule>> {
+        self.decode_protobuf(buf, |codec, data| {
+            codec.try_decode_transformation_rule(data)
+        })
+    }
+
+    fn try_encode_transformation_rule(
+        &self,
+        node: &dyn ExecutionTransformationRule,
+        buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        self.encode_protobuf(buf, |codec, data| {
+            codec.try_encode_transformation_rule(node, data)
+        })
     }
 }
 

--- a/datafusion/proto/src/physical_plan/to_proto.rs
+++ b/datafusion/proto/src/physical_plan/to_proto.rs
@@ -37,7 +37,8 @@ use datafusion_physical_expr_common::physical_expr::snapshot_physical_expr;
 use datafusion_physical_expr_common::sort_expr::PhysicalSortExpr;
 use datafusion_physical_plan::expressions::{
     BinaryExpr, CaseExpr, CastExpr, Column, InListExpr, IsNotNullExpr, IsNullExpr,
-    LikeExpr, Literal, NegativeExpr, NotExpr, TryCastExpr, UnKnownColumn,
+    LikeExpr, Literal, NegativeExpr, NotExpr, PlaceholderExpr, TryCastExpr,
+    UnKnownColumn,
 };
 use datafusion_physical_plan::joins::{HashExpr, HashTableLookupExpr};
 use datafusion_physical_plan::udaf::AggregateFunctionExpr;
@@ -504,6 +505,20 @@ pub fn serialize_physical_expr_with_converter(
                     seed2: s2,
                     seed3: s3,
                     description: expr.description().to_string(),
+                },
+            )),
+        })
+    } else if let Some(expr) = expr.downcast_ref::<PlaceholderExpr>() {
+        Ok(protobuf::PhysicalExprNode {
+            expr_id: None,
+            expr_type: Some(protobuf::physical_expr_node::ExprType::PlaceholderExpr(
+                protobuf::PhysicalPlaceholderNode {
+                    id: expr.id.clone(),
+                    field: expr
+                        .field
+                        .as_ref()
+                        .map(|f| f.as_ref().try_into())
+                        .transpose()?,
                 },
             )),
         })

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -2362,6 +2362,23 @@ async fn roundtrip_async_func_exec() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn roundtrip_resolve_placeholders_exec() -> Result<()> {
+    let ctx = SessionContext::new();
+    ctx.register_table(
+        "t",
+        Arc::new(EmptyTable::new(Arc::new(Schema::new(Fields::from([
+            Arc::new(Field::new("f", DataType::Int64, false)),
+        ]))))),
+    )?;
+    let plan = ctx
+        .sql("select * from t where f = $foo")
+        .await?
+        .create_physical_plan()
+        .await?;
+    roundtrip_test(plan)
+}
+
 /// Test that HashTableLookupExpr serializes to lit(true)
 ///
 /// HashTableLookupExpr contains a runtime hash table that cannot be serialized.

--- a/datafusion/sqllogictest/test_files/explain.slt
+++ b/datafusion/sqllogictest/test_files/explain.slt
@@ -227,6 +227,7 @@ initial_physical_plan_with_schema DataSourceExec: file_groups={1 group: [[WORKSP
 physical_plan after OutputRequirements
 01)OutputRequirementExec: order_by=[], dist_by=Unspecified
 02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/example.csv]]}, projection=[a, b, c], file_type=csv, has_header=true
+physical_plan after PhysicalExprResolver SAME TEXT AS ABOVE
 physical_plan after aggregate_statistics SAME TEXT AS ABOVE
 physical_plan after join_selection SAME TEXT AS ABOVE
 physical_plan after LimitedDistinctAggregation SAME TEXT AS ABOVE
@@ -243,6 +244,7 @@ physical_plan after LimitPushdown SAME TEXT AS ABOVE
 physical_plan after ProjectionPushdown SAME TEXT AS ABOVE
 physical_plan after PushdownSort SAME TEXT AS ABOVE
 physical_plan after EnsureCooperative SAME TEXT AS ABOVE
+physical_plan after PhysicalExprResolver(Post) SAME TEXT AS ABOVE
 physical_plan after FilterPushdown(Post) SAME TEXT AS ABOVE
 physical_plan after SanityCheckPlan SAME TEXT AS ABOVE
 physical_plan DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/example.csv]]}, projection=[a, b, c], file_type=csv, has_header=true
@@ -305,6 +307,7 @@ physical_plan after OutputRequirements
 01)OutputRequirementExec: order_by=[], dist_by=Unspecified, statistics=[Rows=Exact(8), Bytes=Absent, [(Col[0]: ScanBytes=Exact(32)),(Col[1]: ScanBytes=Inexact(24)),(Col[2]: ScanBytes=Exact(32)),(Col[3]: ScanBytes=Exact(32)),(Col[4]: ScanBytes=Exact(32)),(Col[5]: ScanBytes=Exact(64)),(Col[6]: ScanBytes=Exact(32)),(Col[7]: ScanBytes=Exact(64)),(Col[8]: ScanBytes=Inexact(88)),(Col[9]: ScanBytes=Inexact(49)),(Col[10]: ScanBytes=Exact(64))]]
 02)--GlobalLimitExec: skip=0, fetch=10, statistics=[Rows=Exact(8), Bytes=Absent, [(Col[0]: ScanBytes=Exact(32)),(Col[1]: ScanBytes=Inexact(24)),(Col[2]: ScanBytes=Exact(32)),(Col[3]: ScanBytes=Exact(32)),(Col[4]: ScanBytes=Exact(32)),(Col[5]: ScanBytes=Exact(64)),(Col[6]: ScanBytes=Exact(32)),(Col[7]: ScanBytes=Exact(64)),(Col[8]: ScanBytes=Inexact(88)),(Col[9]: ScanBytes=Inexact(49)),(Col[10]: ScanBytes=Exact(64))]]
 03)----DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[id, bool_col, tinyint_col, smallint_col, int_col, bigint_col, float_col, double_col, date_string_col, string_col, timestamp_col], limit=10, file_type=parquet, statistics=[Rows=Exact(8), Bytes=Absent, [(Col[0]: ScanBytes=Exact(32)),(Col[1]: ScanBytes=Inexact(24)),(Col[2]: ScanBytes=Exact(32)),(Col[3]: ScanBytes=Exact(32)),(Col[4]: ScanBytes=Exact(32)),(Col[5]: ScanBytes=Exact(64)),(Col[6]: ScanBytes=Exact(32)),(Col[7]: ScanBytes=Exact(64)),(Col[8]: ScanBytes=Inexact(88)),(Col[9]: ScanBytes=Inexact(49)),(Col[10]: ScanBytes=Exact(64))]]
+physical_plan after PhysicalExprResolver SAME TEXT AS ABOVE
 physical_plan after aggregate_statistics SAME TEXT AS ABOVE
 physical_plan after join_selection SAME TEXT AS ABOVE
 physical_plan after LimitedDistinctAggregation SAME TEXT AS ABOVE
@@ -323,6 +326,7 @@ physical_plan after LimitPushdown DataSourceExec: file_groups={1 group: [[WORKSP
 physical_plan after ProjectionPushdown SAME TEXT AS ABOVE
 physical_plan after PushdownSort SAME TEXT AS ABOVE
 physical_plan after EnsureCooperative SAME TEXT AS ABOVE
+physical_plan after PhysicalExprResolver(Post) SAME TEXT AS ABOVE
 physical_plan after FilterPushdown(Post) SAME TEXT AS ABOVE
 physical_plan after SanityCheckPlan SAME TEXT AS ABOVE
 physical_plan DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[id, bool_col, tinyint_col, smallint_col, int_col, bigint_col, float_col, double_col, date_string_col, string_col, timestamp_col], limit=10, file_type=parquet, statistics=[Rows=Exact(8), Bytes=Absent, [(Col[0]: ScanBytes=Exact(32)),(Col[1]: ScanBytes=Inexact(24)),(Col[2]: ScanBytes=Exact(32)),(Col[3]: ScanBytes=Exact(32)),(Col[4]: ScanBytes=Exact(32)),(Col[5]: ScanBytes=Exact(64)),(Col[6]: ScanBytes=Exact(32)),(Col[7]: ScanBytes=Exact(64)),(Col[8]: ScanBytes=Inexact(88)),(Col[9]: ScanBytes=Inexact(49)),(Col[10]: ScanBytes=Exact(64))]]
@@ -349,6 +353,7 @@ physical_plan after OutputRequirements
 01)OutputRequirementExec: order_by=[], dist_by=Unspecified
 02)--GlobalLimitExec: skip=0, fetch=10
 03)----DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[id, bool_col, tinyint_col, smallint_col, int_col, bigint_col, float_col, double_col, date_string_col, string_col, timestamp_col], limit=10, file_type=parquet
+physical_plan after PhysicalExprResolver SAME TEXT AS ABOVE
 physical_plan after aggregate_statistics SAME TEXT AS ABOVE
 physical_plan after join_selection SAME TEXT AS ABOVE
 physical_plan after LimitedDistinctAggregation SAME TEXT AS ABOVE
@@ -367,6 +372,7 @@ physical_plan after LimitPushdown DataSourceExec: file_groups={1 group: [[WORKSP
 physical_plan after ProjectionPushdown SAME TEXT AS ABOVE
 physical_plan after PushdownSort SAME TEXT AS ABOVE
 physical_plan after EnsureCooperative SAME TEXT AS ABOVE
+physical_plan after PhysicalExprResolver(Post) SAME TEXT AS ABOVE
 physical_plan after FilterPushdown(Post) SAME TEXT AS ABOVE
 physical_plan after SanityCheckPlan SAME TEXT AS ABOVE
 physical_plan DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[id, bool_col, tinyint_col, smallint_col, int_col, bigint_col, float_col, double_col, date_string_col, string_col, timestamp_col], limit=10, file_type=parquet
@@ -588,6 +594,7 @@ initial_physical_plan_with_schema DataSourceExec: file_groups={1 group: [[WORKSP
 physical_plan after OutputRequirements
 01)OutputRequirementExec: order_by=[], dist_by=Unspecified
 02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/example.csv]]}, projection=[a, b, c], file_type=csv, has_header=true
+physical_plan after PhysicalExprResolver SAME TEXT AS ABOVE
 physical_plan after aggregate_statistics SAME TEXT AS ABOVE
 physical_plan after join_selection SAME TEXT AS ABOVE
 physical_plan after LimitedDistinctAggregation SAME TEXT AS ABOVE
@@ -604,6 +611,7 @@ physical_plan after LimitPushdown SAME TEXT AS ABOVE
 physical_plan after ProjectionPushdown SAME TEXT AS ABOVE
 physical_plan after PushdownSort SAME TEXT AS ABOVE
 physical_plan after EnsureCooperative SAME TEXT AS ABOVE
+physical_plan after PhysicalExprResolver(Post) SAME TEXT AS ABOVE
 physical_plan after FilterPushdown(Post) SAME TEXT AS ABOVE
 physical_plan after SanityCheckPlan SAME TEXT AS ABOVE
 physical_plan DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/example.csv]]}, projection=[a, b, c], file_type=csv, has_header=true

--- a/datafusion/sqllogictest/test_files/placeholders.slt
+++ b/datafusion/sqllogictest/test_files/placeholders.slt
@@ -1,0 +1,506 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+##########
+## Test physical plans with placeholders.
+##########
+
+statement ok
+CREATE TABLE t1(
+  id INT,
+  name TEXT
+) as VALUES
+  (1, 'Alex'),
+  (2, 'Bob'),
+  (3, 'Alice')
+
+# Filter with multiple placeholders
+query TT
+EXPLAIN SELECT id FROM t1 WHERE name = $1 OR id = $2
+----
+logical_plan
+01)Projection: t1.id
+02)--Filter: t1.name = $1 OR t1.id = $2
+03)----TableScan: t1 projection=[id, name]
+physical_plan
+01)FilterExec: name@1 = $1 OR id@0 = $2, projection=[id@0]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Projection with placeholder
+query TT
+EXPLAIN SELECT id + $1 FROM t1
+----
+logical_plan
+01)Projection: t1.id + $1
+02)--TableScan: t1 projection=[id]
+physical_plan
+01)ProjectionExec: expr=[id@0 + $1 as t1.id + $1]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Projection and filter with placeholders
+query TT
+EXPLAIN SELECT id + $1 FROM t1 WHERE name = $2
+----
+logical_plan
+01)Projection: t1.id + $1
+02)--Filter: t1.name = $2
+03)----TableScan: t1 projection=[id, name]
+physical_plan
+01)ProjectionExec: expr=[id@0 + $1 as t1.id + $1]
+02)--RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----FilterExec: name@1 = $2
+04)------DataSourceExec: partitions=1, partition_sizes=[1]
+
+statement ok
+DROP TABLE t1
+
+statement ok
+CREATE EXTERNAL TABLE agg_order (
+c1 INT NOT NULL,
+c2 INT NOT NULL,
+c3 INT NOT NULL
+)
+STORED AS CSV
+LOCATION '../core/tests/data/aggregate_agg_multi_order.csv'
+OPTIONS ('format.has_header' 'true');
+
+# Aggregate with placeholder in expression and ordering
+query TT
+EXPLAIN SELECT array_agg(c1 + $1 ORDER BY c2 DESC, c3) FROM agg_order;
+----
+logical_plan
+01)Aggregate: groupBy=[[]], aggr=[[array_agg(agg_order.c1 + $1) ORDER BY [agg_order.c2 DESC NULLS FIRST, agg_order.c3 ASC NULLS LAST]]]
+02)--TableScan: agg_order projection=[c1, c2, c3]
+physical_plan
+01)AggregateExec: mode=Final, gby=[], aggr=[array_agg(agg_order.c1 + $1) ORDER BY [agg_order.c2 DESC NULLS FIRST, agg_order.c3 ASC NULLS LAST]]
+02)--CoalescePartitionsExec
+03)----AggregateExec: mode=Partial, gby=[], aggr=[array_agg(agg_order.c1 + $1) ORDER BY [agg_order.c2 DESC NULLS FIRST, agg_order.c3 ASC NULLS LAST]]
+04)------SortExec: expr=[c2@1 DESC, c3@2 ASC NULLS LAST], preserve_partitioning=[true]
+05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+06)----------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/aggregate_agg_multi_order.csv]]}, projection=[c1, c2, c3], file_type=csv, has_header=true
+
+statement ok
+DROP TABLE agg_order
+
+statement ok
+CREATE EXTERNAL TABLE alltypes_plain STORED AS PARQUET LOCATION '../../parquet-testing/data/alltypes_plain.parquet';
+
+statement ok
+SET datafusion.execution.parquet.pushdown_filters = true;
+
+statement ok
+SET datafusion.execution.parquet.pushdown_filters = true;
+
+# Filter with placeholder and parquet pushdown
+query TT
+EXPLAIN SELECT smallint_col FROM alltypes_plain WHERE int_col = $1;
+----
+logical_plan
+01)Projection: alltypes_plain.smallint_col
+02)--Filter: alltypes_plain.int_col = $1
+03)----TableScan: alltypes_plain projection=[smallint_col, int_col], partial_filters=[alltypes_plain.int_col = $1]
+physical_plan DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[smallint_col], file_type=parquet, predicate=int_col@4 = $1, pruning_predicate=int_col_null_count@2 != row_count@3 AND int_col_min@0 <= $1 AND $1 <= int_col_max@1, required_guarantees=[]
+
+# Projection with placeholder on parquet table
+query TT
+EXPLAIN SELECT smallint_col + $1 FROM alltypes_plain;
+----
+logical_plan
+01)Projection: alltypes_plain.smallint_col + $1
+02)--TableScan: alltypes_plain projection=[smallint_col]
+physical_plan DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[smallint_col@3 + $1 as alltypes_plain.smallint_col + $1], file_type=parquet
+
+# Projection and filter with placeholders on parquet table
+query TT
+EXPLAIN select smallint_col + $1 FROM alltypes_plain WHERE int_col = $2
+----
+logical_plan
+01)Projection: alltypes_plain.smallint_col + $1
+02)--Filter: alltypes_plain.int_col = $2
+03)----TableScan: alltypes_plain projection=[smallint_col, int_col], partial_filters=[alltypes_plain.int_col = $2]
+physical_plan
+01)ProjectionExec: expr=[smallint_col@0 + $1 as alltypes_plain.smallint_col + $1]
+02)--RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[smallint_col, int_col], file_type=parquet, predicate=int_col@4 = $2, pruning_predicate=int_col_null_count@2 != row_count@3 AND int_col_min@0 <= $2 AND $2 <= int_col_max@1, required_guarantees=[]
+
+statement ok
+DROP TABLE alltypes_plain;
+
+##########
+## Joins with placeholders
+##########
+
+statement ok
+CREATE TABLE t1(id INT, name TEXT) AS VALUES (1, 'Alex'), (2, 'Bob');
+
+statement ok
+CREATE TABLE t2(id INT, age INT) AS VALUES (1, 25), (2, 30);
+
+# Join with placeholder in filter
+query TT
+EXPLAIN SELECT t1.name, t2.age FROM t1 JOIN t2 ON t1.id + $1 = t2.id;
+----
+logical_plan
+01)Projection: t1.name, t2.age
+02)--Inner Join: t1.id + $1 = t2.id
+03)----TableScan: t1 projection=[id, name]
+04)----TableScan: t2 projection=[id, age]
+physical_plan
+01)ProjectionExec: expr=[name@1 as name, age@0 as age]
+02)--HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, t1.id + $1@2)], projection=[age@1, name@3]
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
+04)----ProjectionExec: expr=[id@0 as id, name@1 as name, id@0 + $1 as t1.id + $1]
+05)------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Join with placeholder in filter
+query TT
+EXPLAIN SELECT t1.name, t2.age FROM t1 JOIN t2 ON t1.id = t2.id WHERE t2.age > $1;
+----
+logical_plan
+01)Projection: t1.name, t2.age
+02)--Inner Join: t1.id = t2.id
+03)----TableScan: t1 projection=[id, name]
+04)----Filter: t2.age > $1
+05)------TableScan: t2 projection=[id, age]
+physical_plan
+01)ProjectionExec: expr=[name@1 as name, age@0 as age]
+02)--HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[age@1, name@3]
+03)----FilterExec: age@1 > $1
+04)------DataSourceExec: partitions=1, partition_sizes=[1]
+05)----DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Join with placeholder in projection
+query TT
+EXPLAIN SELECT t1.name, t2.age + $1 FROM t1 JOIN t2 ON t1.id = t2.id;
+----
+logical_plan
+01)Projection: t1.name, t2.age + $1
+02)--Inner Join: t1.id = t2.id
+03)----TableScan: t1 projection=[id, name]
+04)----TableScan: t2 projection=[id, age]
+physical_plan
+01)ProjectionExec: expr=[name@1 as name, age@3 + $1 as t2.age + $1]
+02)--RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+03)----ProjectionExec: expr=[id@2 as id, name@3 as name, id@0 as id, age@1 as age]
+04)------HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)]
+05)--------DataSourceExec: partitions=1, partition_sizes=[1]
+06)--------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Join with placeholder in ON statement
+query TT
+EXPLAIN SELECT t1.name, t2.age FROM t1 JOIN t2 ON t1.id + t2.id = $1;
+----
+logical_plan
+01)Projection: t1.name, t2.age
+02)--Inner Join:  Filter: t1.id + t2.id = $1
+03)----TableScan: t1 projection=[id, name]
+04)----TableScan: t2 projection=[id, age]
+physical_plan
+01)ProjectionExec: expr=[name@1 as name, age@0 as age]
+02)--NestedLoopJoinExec: join_type=Inner, filter=id@0 + id@1 = $1, projection=[age@1, name@3]
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
+04)----DataSourceExec: partitions=1, partition_sizes=[1]
+
+statement ok
+DROP TABLE t1;
+
+##########
+## Window Functions and UNION with placeholders
+##########
+
+statement ok
+CREATE TABLE t1(id INT, name TEXT) AS VALUES (1, 'Alex'), (2, 'Bob');
+
+# Window function with placeholder
+query TT
+EXPLAIN SELECT id, SUM(id) OVER (PARTITION BY name ORDER BY id) + $1 FROM t1;
+----
+logical_plan
+01)Projection: t1.id, sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW + $1
+02)--WindowAggr: windowExpr=[[sum(CAST(t1.id AS Int64)) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
+03)----TableScan: t1 projection=[id, name]
+physical_plan
+01)ProjectionExec: expr=[id@0 as id, sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@2 + $1 as sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW + $1]
+02)--BoundedWindowAggExec: wdw=[sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Field { "sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW": nullable Int64 }, frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], mode=[Sorted]
+03)----SortExec: expr=[name@1 ASC NULLS LAST, id@0 ASC NULLS LAST], preserve_partitioning=[false]
+04)------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Window function with placeholder
+# Here we only resolve BoundedWindowAggExec.
+query TT
+EXPLAIN SELECT id, SUM(id + $1) OVER (PARTITION BY name ORDER BY id) FROM t1;
+----
+logical_plan
+01)Projection: t1.id, sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+02)--WindowAggr: windowExpr=[[sum(CAST(t1.id + $1 AS Int64)) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
+03)----TableScan: t1 projection=[id, name]
+physical_plan
+01)ProjectionExec: expr=[id@0 as id, sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@2 as sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]
+02)--BoundedWindowAggExec: wdw=[sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Field { "sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW": nullable Int64 }, frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], mode=[Sorted]
+03)----SortExec: expr=[name@1 ASC NULLS LAST, id@0 ASC NULLS LAST], preserve_partitioning=[false]
+04)------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# UNION with placeholder
+query TT
+EXPLAIN SELECT id FROM t1 WHERE id = $1 UNION ALL SELECT id FROM t1 WHERE id = $2;
+----
+logical_plan
+01)Union
+02)--Filter: t1.id = $1
+03)----TableScan: t1 projection=[id]
+04)--Filter: t1.id = $2
+05)----TableScan: t1 projection=[id]
+physical_plan
+01)UnionExec
+02)--FilterExec: id@0 = $1
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
+04)--FilterExec: id@0 = $2
+05)----DataSourceExec: partitions=1, partition_sizes=[1]
+
+statement ok
+DROP TABLE t1;
+
+##########
+## Subqueries and CTEs with placeholders
+##########
+
+statement ok
+CREATE TABLE t1(id INT, name TEXT) AS VALUES (1, 'Alex'), (2, 'Bob');
+
+# Scalar subquery with placeholder
+query TT
+EXPLAIN SELECT id, (SELECT name FROM t1 WHERE id = $1) FROM t1;
+----
+logical_plan
+01)Projection: t1.id, __scalar_sq_1.name AS name
+02)--Left Join:
+03)----TableScan: t1 projection=[id]
+04)----SubqueryAlias: __scalar_sq_1
+05)------Projection: t1.name
+06)--------Filter: t1.id = $1
+07)----------TableScan: t1 projection=[id, name]
+physical_plan
+01)ProjectionExec: expr=[id@1 as id, name@0 as name]
+02)--NestedLoopJoinExec: join_type=Right
+03)----FilterExec: id@0 = $1, projection=[name@1]
+04)------DataSourceExec: partitions=1, partition_sizes=[1]
+05)----DataSourceExec: partitions=1, partition_sizes=[1]
+
+# CTE with placeholder
+query TT
+EXPLAIN WITH cte AS (SELECT * FROM t1 WHERE id = $1) SELECT * FROM cte;
+----
+logical_plan
+01)SubqueryAlias: cte
+02)--Filter: t1.id = $1
+03)----TableScan: t1 projection=[id, name]
+physical_plan
+01)FilterExec: id@0 = $1
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+statement ok
+DROP TABLE t1;
+
+##########
+## Group By and Order By with placeholders
+##########
+
+statement ok
+CREATE TABLE t1(id INT, name TEXT) AS VALUES (1, 'Alex'), (2, 'Bob'), (3, 'Alice');
+
+# Group by with placeholder in SELECT
+query TT
+EXPLAIN SELECT id + $1, COUNT(*) FROM t1 GROUP BY id;
+----
+logical_plan
+01)Projection: t1.id + $1, count(Int64(1)) AS count(*)
+02)--Aggregate: groupBy=[[t1.id]], aggr=[[count(Int64(1))]]
+03)----TableScan: t1 projection=[id]
+physical_plan
+01)ProjectionExec: expr=[id@0 + $1 as t1.id + $1, count(Int64(1))@1 as count(*)]
+02)--AggregateExec: mode=FinalPartitioned, gby=[id@0 as id], aggr=[count(Int64(1))]
+03)----RepartitionExec: partitioning=Hash([id@0], 4), input_partitions=1
+04)------AggregateExec: mode=Partial, gby=[id@0 as id], aggr=[count(Int64(1))]
+05)--------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Group by with placeholder in HAVING
+query TT
+EXPLAIN SELECT id, COUNT(*) FROM t1 GROUP BY id HAVING COUNT(*) > $1;
+----
+logical_plan
+01)Projection: t1.id, count(Int64(1)) AS count(*)
+02)--Filter: count(Int64(1)) > CAST($1 AS Int64)
+03)----Aggregate: groupBy=[[t1.id]], aggr=[[count(Int64(1))]]
+04)------TableScan: t1 projection=[id]
+physical_plan
+01)ProjectionExec: expr=[id@0 as id, count(Int64(1))@1 as count(*)]
+02)--FilterExec: count(Int64(1))@1 > $1
+03)----AggregateExec: mode=FinalPartitioned, gby=[id@0 as id], aggr=[count(Int64(1))]
+04)------RepartitionExec: partitioning=Hash([id@0], 4), input_partitions=1
+05)--------AggregateExec: mode=Partial, gby=[id@0 as id], aggr=[count(Int64(1))]
+06)----------DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Order by with placeholder
+query TT
+EXPLAIN SELECT id FROM t1 ORDER BY id + $1;
+----
+logical_plan
+01)Sort: t1.id + CAST($1 AS Int32) ASC NULLS LAST
+02)--TableScan: t1 projection=[id]
+physical_plan
+01)SortExec: expr=[id@0 + $1 ASC NULLS LAST], preserve_partitioning=[false]
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Group by and Order by with placeholders
+query TT
+EXPLAIN SELECT name, SUM(id) FROM t1 GROUP BY name ORDER BY SUM(id) + $1;
+----
+logical_plan
+01)Sort: sum(t1.id) + CAST($1 AS Int64) ASC NULLS LAST
+02)--Aggregate: groupBy=[[t1.name]], aggr=[[sum(CAST(t1.id AS Int64))]]
+03)----TableScan: t1 projection=[id, name]
+physical_plan
+01)SortPreservingMergeExec: [sum(t1.id)@1 + $1 ASC NULLS LAST]
+02)--SortExec: expr=[sum(t1.id)@1 + $1 ASC NULLS LAST], preserve_partitioning=[true]
+03)----AggregateExec: mode=FinalPartitioned, gby=[name@0 as name], aggr=[sum(t1.id)]
+04)------RepartitionExec: partitioning=Hash([name@0], 4), input_partitions=1
+05)--------AggregateExec: mode=Partial, gby=[name@1 as name], aggr=[sum(t1.id)]
+06)----------DataSourceExec: partitions=1, partition_sizes=[1]
+
+statement ok
+DROP TABLE t1;
+
+##########
+## CAST and TRY_CAST with placeholders
+##########
+
+# Implicit CAST with placeholder
+query TT
+EXPLAIN SELECT $1::INT;
+----
+logical_plan
+01)Projection: CAST($1 AS Int32)
+02)--EmptyRelation: rows=1
+physical_plan
+01)ProjectionExec: expr=[$1]
+02)--PlaceholderRowExec
+
+# CAST with placeholder
+query TT
+EXPLAIN SELECT CAST($1 AS INT);
+----
+logical_plan
+01)Projection: CAST($1 AS Int32)
+02)--EmptyRelation: rows=1
+physical_plan
+01)ProjectionExec: expr=[$1]
+02)--PlaceholderRowExec
+
+# TRY_CAST with placeholder
+query TT
+EXPLAIN SELECT TRY_CAST($1 AS INT);
+----
+logical_plan
+01)Projection: TRY_CAST($1 AS Int32)
+02)--EmptyRelation: rows=1
+physical_plan
+01)ProjectionExec: expr=[TRY_CAST($1 AS Int32) as $1]
+02)--PlaceholderRowExec
+
+##########
+## IN and BETWEEN with placeholders
+##########
+
+statement ok
+CREATE TABLE t1(id INT, name TEXT) AS VALUES (1, 'Alex'), (2, 'Bob'), (3, 'Alice');
+
+# IN with placeholders
+query TT
+EXPLAIN SELECT id FROM t1 WHERE id IN ($1, $2, $3);
+----
+logical_plan
+01)Filter: t1.id = $1 OR t1.id = $2 OR t1.id = $3
+02)--TableScan: t1 projection=[id]
+physical_plan
+01)FilterExec: id@0 = $1 OR id@0 = $2 OR id@0 = $3
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+# BETWEEN with placeholders
+query TT
+EXPLAIN SELECT id FROM t1 WHERE id BETWEEN $1 AND $2;
+----
+logical_plan
+01)Filter: t1.id >= $1 AND t1.id <= $2
+02)--TableScan: t1 projection=[id]
+physical_plan
+01)FilterExec: id@0 >= $1 AND id@0 <= $2
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+##########
+## String and Arithmetic operations with placeholders
+##########
+
+# String concatenation with placeholders
+query TT
+EXPLAIN SELECT $1::TEXT || $2::TEXT;
+----
+logical_plan
+01)Projection: CAST($1 AS Utf8View) || CAST($2 AS Utf8View)
+02)--EmptyRelation: rows=1
+physical_plan
+01)ProjectionExec: expr=[$1 || $2]
+02)--PlaceholderRowExec
+
+# Arithmetic with placeholders
+query TT
+EXPLAIN SELECT $1 + $2 * $3;
+----
+logical_plan
+01)Projection: $1 + CAST($2 AS Int64) * CAST($3 AS Int64)
+02)--EmptyRelation: rows=1
+physical_plan
+01)ProjectionExec: expr=[$1 + CAST($2 AS Int64) * CAST($3 AS Int64) as $1 + $2 * $3]
+02)--PlaceholderRowExec
+
+##########
+## LIKE and Regex with placeholders
+##########
+
+# LIKE with placeholder
+query TT
+EXPLAIN SELECT * FROM t1 WHERE name LIKE $1;
+----
+logical_plan
+01)Filter: t1.name LIKE $1
+02)--TableScan: t1 projection=[id, name]
+physical_plan
+01)FilterExec: name@1 LIKE $1
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+# Regex with placeholder
+query TT
+EXPLAIN SELECT * FROM t1 WHERE name ~ $1;
+----
+logical_plan
+01)Filter: t1.name ~ $1
+02)--TableScan: t1 projection=[id, name]
+physical_plan
+01)FilterExec: name@1 ~ $1
+02)--DataSourceExec: partitions=1, partition_sizes=[1]
+
+statement ok
+DROP TABLE t1;

--- a/datafusion/sqllogictest/test_files/placeholders.slt
+++ b/datafusion/sqllogictest/test_files/placeholders.slt
@@ -17,6 +17,15 @@
 
 ##########
 ## Test physical plans with placeholders.
+##
+## These tests verify that the physical planner correctly produces a
+## `TransformPlanExec` node with the expected number of plans with
+## placeholders.
+##
+## A test is considered successful when the physical plan contains
+## `TransformPlanExec`, indicating that the plan can be traversed to find
+## placeholders and successfully replace them with actual parameter values
+## during execution.
 ##########
 
 statement ok
@@ -37,8 +46,9 @@ logical_plan
 02)--Filter: t1.name = $1 OR t1.id = $2
 03)----TableScan: t1 projection=[id, name]
 physical_plan
-01)FilterExec: name@1 = $1 OR id@0 = $2, projection=[id@0]
-02)--DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--FilterExec: name@1 = $1 OR id@0 = $2, projection=[id@0]
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Projection with placeholder
 query TT
@@ -48,8 +58,9 @@ logical_plan
 01)Projection: t1.id + $1
 02)--TableScan: t1 projection=[id]
 physical_plan
-01)ProjectionExec: expr=[id@0 + $1 as t1.id + $1]
-02)--DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[id@0 + $1 as t1.id + $1]
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Projection and filter with placeholders
 query TT
@@ -60,10 +71,11 @@ logical_plan
 02)--Filter: t1.name = $2
 03)----TableScan: t1 projection=[id, name]
 physical_plan
-01)ProjectionExec: expr=[id@0 + $1 as t1.id + $1]
-02)--RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-03)----FilterExec: name@1 = $2
-04)------DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=2]
+02)--ProjectionExec: expr=[id@0 + $1 as t1.id + $1]
+03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------FilterExec: name@1 = $2
+05)--------DataSourceExec: partitions=1, partition_sizes=[1]
 
 statement ok
 DROP TABLE t1
@@ -86,12 +98,13 @@ logical_plan
 01)Aggregate: groupBy=[[]], aggr=[[array_agg(agg_order.c1 + $1) ORDER BY [agg_order.c2 DESC NULLS FIRST, agg_order.c3 ASC NULLS LAST]]]
 02)--TableScan: agg_order projection=[c1, c2, c3]
 physical_plan
-01)AggregateExec: mode=Final, gby=[], aggr=[array_agg(agg_order.c1 + $1) ORDER BY [agg_order.c2 DESC NULLS FIRST, agg_order.c3 ASC NULLS LAST]]
-02)--CoalescePartitionsExec
-03)----AggregateExec: mode=Partial, gby=[], aggr=[array_agg(agg_order.c1 + $1) ORDER BY [agg_order.c2 DESC NULLS FIRST, agg_order.c3 ASC NULLS LAST]]
-04)------SortExec: expr=[c2@1 DESC, c3@2 ASC NULLS LAST], preserve_partitioning=[true]
-05)--------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-06)----------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/aggregate_agg_multi_order.csv]]}, projection=[c1, c2, c3], file_type=csv, has_header=true
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=2]
+02)--AggregateExec: mode=Final, gby=[], aggr=[array_agg(agg_order.c1 + $1) ORDER BY [agg_order.c2 DESC NULLS FIRST, agg_order.c3 ASC NULLS LAST]]
+03)----CoalescePartitionsExec
+04)------AggregateExec: mode=Partial, gby=[], aggr=[array_agg(agg_order.c1 + $1) ORDER BY [agg_order.c2 DESC NULLS FIRST, agg_order.c3 ASC NULLS LAST]]
+05)--------SortExec: expr=[c2@1 DESC, c3@2 ASC NULLS LAST], preserve_partitioning=[true]
+06)----------RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+07)------------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/datafusion/core/tests/data/aggregate_agg_multi_order.csv]]}, projection=[c1, c2, c3], file_type=csv, has_header=true
 
 statement ok
 DROP TABLE agg_order
@@ -113,7 +126,9 @@ logical_plan
 01)Projection: alltypes_plain.smallint_col
 02)--Filter: alltypes_plain.int_col = $1
 03)----TableScan: alltypes_plain projection=[smallint_col, int_col], partial_filters=[alltypes_plain.int_col = $1]
-physical_plan DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[smallint_col], file_type=parquet, predicate=int_col@4 = $1, pruning_predicate=int_col_null_count@2 != row_count@3 AND int_col_min@0 <= $1 AND $1 <= int_col_max@1, required_guarantees=[]
+physical_plan
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[smallint_col], file_type=parquet, predicate=int_col@4 = $1, pruning_predicate=int_col_null_count@2 != row_count@3 AND int_col_min@0 <= $1 AND $1 <= int_col_max@1, required_guarantees=[]
 
 # Projection with placeholder on parquet table
 query TT
@@ -122,7 +137,9 @@ EXPLAIN SELECT smallint_col + $1 FROM alltypes_plain;
 logical_plan
 01)Projection: alltypes_plain.smallint_col + $1
 02)--TableScan: alltypes_plain projection=[smallint_col]
-physical_plan DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[smallint_col@3 + $1 as alltypes_plain.smallint_col + $1], file_type=parquet
+physical_plan
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[smallint_col@3 + $1 as alltypes_plain.smallint_col + $1], file_type=parquet
 
 # Projection and filter with placeholders on parquet table
 query TT
@@ -133,9 +150,10 @@ logical_plan
 02)--Filter: alltypes_plain.int_col = $2
 03)----TableScan: alltypes_plain projection=[smallint_col, int_col], partial_filters=[alltypes_plain.int_col = $2]
 physical_plan
-01)ProjectionExec: expr=[smallint_col@0 + $1 as alltypes_plain.smallint_col + $1]
-02)--RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-03)----DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[smallint_col, int_col], file_type=parquet, predicate=int_col@4 = $2, pruning_predicate=int_col_null_count@2 != row_count@3 AND int_col_min@0 <= $2 AND $2 <= int_col_max@1, required_guarantees=[]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=2]
+02)--ProjectionExec: expr=[smallint_col@0 + $1 as alltypes_plain.smallint_col + $1]
+03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------DataSourceExec: file_groups={1 group: [[WORKSPACE_ROOT/parquet-testing/data/alltypes_plain.parquet]]}, projection=[smallint_col, int_col], file_type=parquet, predicate=int_col@4 = $2, pruning_predicate=int_col_null_count@2 != row_count@3 AND int_col_min@0 <= $2 AND $2 <= int_col_max@1, required_guarantees=[]
 
 statement ok
 DROP TABLE alltypes_plain;
@@ -160,11 +178,12 @@ logical_plan
 03)----TableScan: t1 projection=[id, name]
 04)----TableScan: t2 projection=[id, age]
 physical_plan
-01)ProjectionExec: expr=[name@1 as name, age@0 as age]
-02)--HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, t1.id + $1@2)], projection=[age@1, name@3]
-03)----DataSourceExec: partitions=1, partition_sizes=[1]
-04)----ProjectionExec: expr=[id@0 as id, name@1 as name, id@0 + $1 as t1.id + $1]
-05)------DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[name@1 as name, age@0 as age]
+03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, t1.id + $1@2)], projection=[age@1, name@3]
+04)------DataSourceExec: partitions=1, partition_sizes=[1]
+05)------ProjectionExec: expr=[id@0 as id, name@1 as name, id@0 + $1 as t1.id + $1]
+06)--------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Join with placeholder in filter
 query TT
@@ -177,11 +196,12 @@ logical_plan
 04)----Filter: t2.age > $1
 05)------TableScan: t2 projection=[id, age]
 physical_plan
-01)ProjectionExec: expr=[name@1 as name, age@0 as age]
-02)--HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[age@1, name@3]
-03)----FilterExec: age@1 > $1
-04)------DataSourceExec: partitions=1, partition_sizes=[1]
-05)----DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[name@1 as name, age@0 as age]
+03)----HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)], projection=[age@1, name@3]
+04)------FilterExec: age@1 > $1
+05)--------DataSourceExec: partitions=1, partition_sizes=[1]
+06)------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Join with placeholder in projection
 query TT
@@ -193,12 +213,13 @@ logical_plan
 03)----TableScan: t1 projection=[id, name]
 04)----TableScan: t2 projection=[id, age]
 physical_plan
-01)ProjectionExec: expr=[name@1 as name, age@3 + $1 as t2.age + $1]
-02)--RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-03)----ProjectionExec: expr=[id@2 as id, name@3 as name, id@0 as id, age@1 as age]
-04)------HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)]
-05)--------DataSourceExec: partitions=1, partition_sizes=[1]
-06)--------DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[name@1 as name, age@3 + $1 as t2.age + $1]
+03)----RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+04)------ProjectionExec: expr=[id@2 as id, name@3 as name, id@0 as id, age@1 as age]
+05)--------HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, id@0)]
+06)----------DataSourceExec: partitions=1, partition_sizes=[1]
+07)----------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Join with placeholder in ON statement
 query TT
@@ -210,10 +231,11 @@ logical_plan
 03)----TableScan: t1 projection=[id, name]
 04)----TableScan: t2 projection=[id, age]
 physical_plan
-01)ProjectionExec: expr=[name@1 as name, age@0 as age]
-02)--NestedLoopJoinExec: join_type=Inner, filter=id@0 + id@1 = $1, projection=[age@1, name@3]
-03)----DataSourceExec: partitions=1, partition_sizes=[1]
-04)----DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[name@1 as name, age@0 as age]
+03)----NestedLoopJoinExec: join_type=Inner, filter=id@0 + id@1 = $1, projection=[age@1, name@3]
+04)------DataSourceExec: partitions=1, partition_sizes=[1]
+05)------DataSourceExec: partitions=1, partition_sizes=[1]
 
 statement ok
 DROP TABLE t1;
@@ -234,10 +256,11 @@ logical_plan
 02)--WindowAggr: windowExpr=[[sum(CAST(t1.id AS Int64)) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
 03)----TableScan: t1 projection=[id, name]
 physical_plan
-01)ProjectionExec: expr=[id@0 as id, sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@2 + $1 as sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW + $1]
-02)--BoundedWindowAggExec: wdw=[sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Field { "sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW": nullable Int64 }, frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], mode=[Sorted]
-03)----SortExec: expr=[name@1 ASC NULLS LAST, id@0 ASC NULLS LAST], preserve_partitioning=[false]
-04)------DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[id@0 as id, sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@2 + $1 as sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW + $1]
+03)----BoundedWindowAggExec: wdw=[sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Field { "sum(t1.id) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW": nullable Int64 }, frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], mode=[Sorted]
+04)------SortExec: expr=[name@1 ASC NULLS LAST, id@0 ASC NULLS LAST], preserve_partitioning=[false]
+05)--------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Window function with placeholder
 # Here we only resolve BoundedWindowAggExec.
@@ -249,10 +272,11 @@ logical_plan
 02)--WindowAggr: windowExpr=[[sum(CAST(t1.id + $1 AS Int64)) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]]
 03)----TableScan: t1 projection=[id, name]
 physical_plan
-01)ProjectionExec: expr=[id@0 as id, sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@2 as sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]
-02)--BoundedWindowAggExec: wdw=[sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Field { "sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW": nullable Int64 }, frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], mode=[Sorted]
-03)----SortExec: expr=[name@1 ASC NULLS LAST, id@0 ASC NULLS LAST], preserve_partitioning=[false]
-04)------DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[id@0 as id, sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW@2 as sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW]
+03)----BoundedWindowAggExec: wdw=[sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW: Field { "sum(t1.id + $1) PARTITION BY [t1.name] ORDER BY [t1.id ASC NULLS LAST] RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW": nullable Int64 }, frame: RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW], mode=[Sorted]
+04)------SortExec: expr=[name@1 ASC NULLS LAST, id@0 ASC NULLS LAST], preserve_partitioning=[false]
+05)--------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # UNION with placeholder
 query TT
@@ -265,11 +289,12 @@ logical_plan
 04)--Filter: t1.id = $2
 05)----TableScan: t1 projection=[id]
 physical_plan
-01)UnionExec
-02)--FilterExec: id@0 = $1
-03)----DataSourceExec: partitions=1, partition_sizes=[1]
-04)--FilterExec: id@0 = $2
-05)----DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=2]
+02)--UnionExec
+03)----FilterExec: id@0 = $1
+04)------DataSourceExec: partitions=1, partition_sizes=[1]
+05)----FilterExec: id@0 = $2
+06)------DataSourceExec: partitions=1, partition_sizes=[1]
 
 statement ok
 DROP TABLE t1;
@@ -294,11 +319,12 @@ logical_plan
 06)--------Filter: t1.id = $1
 07)----------TableScan: t1 projection=[id, name]
 physical_plan
-01)ProjectionExec: expr=[id@1 as id, name@0 as name]
-02)--NestedLoopJoinExec: join_type=Right
-03)----FilterExec: id@0 = $1, projection=[name@1]
-04)------DataSourceExec: partitions=1, partition_sizes=[1]
-05)----DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[id@1 as id, name@0 as name]
+03)----NestedLoopJoinExec: join_type=Right
+04)------FilterExec: id@0 = $1, projection=[name@1]
+05)--------DataSourceExec: partitions=1, partition_sizes=[1]
+06)------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # CTE with placeholder
 query TT
@@ -309,8 +335,9 @@ logical_plan
 02)--Filter: t1.id = $1
 03)----TableScan: t1 projection=[id, name]
 physical_plan
-01)FilterExec: id@0 = $1
-02)--DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--FilterExec: id@0 = $1
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
 
 statement ok
 DROP TABLE t1;
@@ -331,11 +358,12 @@ logical_plan
 02)--Aggregate: groupBy=[[t1.id]], aggr=[[count(Int64(1))]]
 03)----TableScan: t1 projection=[id]
 physical_plan
-01)ProjectionExec: expr=[id@0 + $1 as t1.id + $1, count(Int64(1))@1 as count(*)]
-02)--AggregateExec: mode=FinalPartitioned, gby=[id@0 as id], aggr=[count(Int64(1))]
-03)----RepartitionExec: partitioning=Hash([id@0], 4), input_partitions=1
-04)------AggregateExec: mode=Partial, gby=[id@0 as id], aggr=[count(Int64(1))]
-05)--------DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[id@0 + $1 as t1.id + $1, count(Int64(1))@1 as count(*)]
+03)----AggregateExec: mode=FinalPartitioned, gby=[id@0 as id], aggr=[count(Int64(1))]
+04)------RepartitionExec: partitioning=Hash([id@0], 4), input_partitions=1
+05)--------AggregateExec: mode=Partial, gby=[id@0 as id], aggr=[count(Int64(1))]
+06)----------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Group by with placeholder in HAVING
 query TT
@@ -347,12 +375,13 @@ logical_plan
 03)----Aggregate: groupBy=[[t1.id]], aggr=[[count(Int64(1))]]
 04)------TableScan: t1 projection=[id]
 physical_plan
-01)ProjectionExec: expr=[id@0 as id, count(Int64(1))@1 as count(*)]
-02)--FilterExec: count(Int64(1))@1 > $1
-03)----AggregateExec: mode=FinalPartitioned, gby=[id@0 as id], aggr=[count(Int64(1))]
-04)------RepartitionExec: partitioning=Hash([id@0], 4), input_partitions=1
-05)--------AggregateExec: mode=Partial, gby=[id@0 as id], aggr=[count(Int64(1))]
-06)----------DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[id@0 as id, count(Int64(1))@1 as count(*)]
+03)----FilterExec: count(Int64(1))@1 > $1
+04)------AggregateExec: mode=FinalPartitioned, gby=[id@0 as id], aggr=[count(Int64(1))]
+05)--------RepartitionExec: partitioning=Hash([id@0], 4), input_partitions=1
+06)----------AggregateExec: mode=Partial, gby=[id@0 as id], aggr=[count(Int64(1))]
+07)------------DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Order by with placeholder
 query TT
@@ -362,8 +391,9 @@ logical_plan
 01)Sort: t1.id + CAST($1 AS Int32) ASC NULLS LAST
 02)--TableScan: t1 projection=[id]
 physical_plan
-01)SortExec: expr=[id@0 + $1 ASC NULLS LAST], preserve_partitioning=[false]
-02)--DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--SortExec: expr=[id@0 + $1 ASC NULLS LAST], preserve_partitioning=[false]
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Group by and Order by with placeholders
 query TT
@@ -374,12 +404,13 @@ logical_plan
 02)--Aggregate: groupBy=[[t1.name]], aggr=[[sum(CAST(t1.id AS Int64))]]
 03)----TableScan: t1 projection=[id, name]
 physical_plan
-01)SortPreservingMergeExec: [sum(t1.id)@1 + $1 ASC NULLS LAST]
-02)--SortExec: expr=[sum(t1.id)@1 + $1 ASC NULLS LAST], preserve_partitioning=[true]
-03)----AggregateExec: mode=FinalPartitioned, gby=[name@0 as name], aggr=[sum(t1.id)]
-04)------RepartitionExec: partitioning=Hash([name@0], 4), input_partitions=1
-05)--------AggregateExec: mode=Partial, gby=[name@1 as name], aggr=[sum(t1.id)]
-06)----------DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=2]
+02)--SortPreservingMergeExec: [sum(t1.id)@1 + $1 ASC NULLS LAST]
+03)----SortExec: expr=[sum(t1.id)@1 + $1 ASC NULLS LAST], preserve_partitioning=[true]
+04)------AggregateExec: mode=FinalPartitioned, gby=[name@0 as name], aggr=[sum(t1.id)]
+05)--------RepartitionExec: partitioning=Hash([name@0], 4), input_partitions=1
+06)----------AggregateExec: mode=Partial, gby=[name@1 as name], aggr=[sum(t1.id)]
+07)------------DataSourceExec: partitions=1, partition_sizes=[1]
 
 statement ok
 DROP TABLE t1;
@@ -396,8 +427,9 @@ logical_plan
 01)Projection: CAST($1 AS Int32)
 02)--EmptyRelation: rows=1
 physical_plan
-01)ProjectionExec: expr=[$1]
-02)--PlaceholderRowExec
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[$1]
+03)----PlaceholderRowExec
 
 # CAST with placeholder
 query TT
@@ -407,8 +439,9 @@ logical_plan
 01)Projection: CAST($1 AS Int32)
 02)--EmptyRelation: rows=1
 physical_plan
-01)ProjectionExec: expr=[$1]
-02)--PlaceholderRowExec
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[$1]
+03)----PlaceholderRowExec
 
 # TRY_CAST with placeholder
 query TT
@@ -418,8 +451,9 @@ logical_plan
 01)Projection: TRY_CAST($1 AS Int32)
 02)--EmptyRelation: rows=1
 physical_plan
-01)ProjectionExec: expr=[TRY_CAST($1 AS Int32) as $1]
-02)--PlaceholderRowExec
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[TRY_CAST($1 AS Int32) as $1]
+03)----PlaceholderRowExec
 
 ##########
 ## IN and BETWEEN with placeholders
@@ -436,8 +470,9 @@ logical_plan
 01)Filter: t1.id = $1 OR t1.id = $2 OR t1.id = $3
 02)--TableScan: t1 projection=[id]
 physical_plan
-01)FilterExec: id@0 = $1 OR id@0 = $2 OR id@0 = $3
-02)--DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--FilterExec: id@0 = $1 OR id@0 = $2 OR id@0 = $3
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
 
 # BETWEEN with placeholders
 query TT
@@ -447,8 +482,9 @@ logical_plan
 01)Filter: t1.id >= $1 AND t1.id <= $2
 02)--TableScan: t1 projection=[id]
 physical_plan
-01)FilterExec: id@0 >= $1 AND id@0 <= $2
-02)--DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--FilterExec: id@0 >= $1 AND id@0 <= $2
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
 
 ##########
 ## String and Arithmetic operations with placeholders
@@ -462,8 +498,9 @@ logical_plan
 01)Projection: CAST($1 AS Utf8View) || CAST($2 AS Utf8View)
 02)--EmptyRelation: rows=1
 physical_plan
-01)ProjectionExec: expr=[$1 || $2]
-02)--PlaceholderRowExec
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[$1 || $2]
+03)----PlaceholderRowExec
 
 # Arithmetic with placeholders
 query TT
@@ -473,8 +510,9 @@ logical_plan
 01)Projection: $1 + CAST($2 AS Int64) * CAST($3 AS Int64)
 02)--EmptyRelation: rows=1
 physical_plan
-01)ProjectionExec: expr=[$1 + CAST($2 AS Int64) * CAST($3 AS Int64) as $1 + $2 * $3]
-02)--PlaceholderRowExec
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--ProjectionExec: expr=[$1 + CAST($2 AS Int64) * CAST($3 AS Int64) as $1 + $2 * $3]
+03)----PlaceholderRowExec
 
 ##########
 ## LIKE and Regex with placeholders
@@ -488,8 +526,9 @@ logical_plan
 01)Filter: t1.name LIKE $1
 02)--TableScan: t1 projection=[id, name]
 physical_plan
-01)FilterExec: name@1 LIKE $1
-02)--DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--FilterExec: name@1 LIKE $1
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
 
 # Regex with placeholder
 query TT
@@ -499,8 +538,9 @@ logical_plan
 01)Filter: t1.name ~ $1
 02)--TableScan: t1 projection=[id, name]
 physical_plan
-01)FilterExec: name@1 ~ $1
-02)--DataSourceExec: partitions=1, partition_sizes=[1]
+01)TransformPlanExec: rules=[ResolvePlaceholders: plans_to_modify=1]
+02)--FilterExec: name@1 ~ $1
+03)----DataSourceExec: partitions=1, partition_sizes=[1]
 
 statement ok
 DROP TABLE t1;


### PR DESCRIPTION
## Rationale for this change

Currently, DataFusion's support for placeholders is handled at the logical plan level. This requires re-planning every time parameter values change.

This PR introduces physical-level support for placeholders, allowing a physical plan to be created once and then executed multiple times with different parameter values. This should improve performance for repeated executions of the same query with different parameters by avoiding the overhead of physical planning.

## What changes are included in this PR?

This PR introduces several key components to support physical placeholders:

**PlaceholderExpr**: A new physical expression that represents a placeholder in the physical plan. It stores the placeholder ID and its data type.
**TransformPlanExec**: A new execution plan node that can rewrite execution plans at execution time.
**PhysicalExprResolver Optimizer Rule**: Wraps the final optimized plan in a `TransformPlanExec` if any unresolved placeholders are detected.
**TaskContext Update**: Updated to carry `ParamValues`.

## Are these changes tested?

`TransformPlanExec` and `PhysicalExprResolver`  are tested with unit tests and SLT tests.

## Are there any user-facing changes?

Yes, a user can now build physical plan from a logical plan with placeholders.