### PR TITLE
feat: share paths to proto files

### DIFF
--- a/datafusion/proto-common/Cargo.toml
+++ b/datafusion/proto-common/Cargo.toml
@@ -27,6 +27,7 @@ repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
+links = "datafusion-proto-common"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/datafusion/proto-common/build.rs
+++ b/datafusion/proto-common/build.rs
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+fn main() -> Result<(), String> {
+    let manifest_dir =
+        std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let proto_include_dir = manifest_dir.join("proto");
+
+    println!("cargo::metadata=INCLUDE={}", proto_include_dir.display());
+
+    Ok(())
+}

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -27,6 +27,7 @@ repository = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
 rust-version = { workspace = true }
+links = "datafusion-proto"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/datafusion/proto/build.rs
+++ b/datafusion/proto/build.rs
@@ -1,0 +1,26 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+fn main() -> Result<(), String> {
+    let manifest_dir =
+        std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let proto_include_dir = manifest_dir.join("proto");
+
+    println!("cargo::metadata=INCLUDE={}", proto_include_dir.display());
+
+    Ok(())
+}

--- a/datafusion/proto/gen/src/main.rs
+++ b/datafusion/proto/gen/src/main.rs
@@ -31,7 +31,10 @@ fn main() -> Result<(), String> {
         .compile_well_known_types()
         .protoc_arg("--experimental_allow_proto3_optional")
         .extern_path(".google.protobuf", "::pbjson_types")
-        .compile_protos(&[proto_path], &["proto"])
+        .compile_protos(
+            &[proto_path],
+            &["datafusion/proto/proto", "datafusion/proto-common/proto"],
+        )
         .map_err(|e| format!("protobuf compilation failed: {e}"))?;
 
     let descriptor_set = std::fs::read(&descriptor_path)

--- a/datafusion/proto/proto/datafusion.proto
+++ b/datafusion/proto/proto/datafusion.proto
@@ -24,7 +24,7 @@ option java_multiple_files = true;
 option java_package = "org.apache.datafusion.protobuf";
 option java_outer_classname = "DatafusionProto";
 
-import "datafusion/proto-common/proto/datafusion_common.proto";
+import "datafusion_common.proto";
 
 // logical plan
 // LogicalPlan is a nested type


### PR DESCRIPTION
By setting the cargo variable, datafusion exports meta information about the path to proto files.